### PR TITLE
Introduction of GGD Validation Rules

### DIFF
--- a/ids_validator/assets/rulesets/generic/ggd.py
+++ b/ids_validator/assets/rulesets/generic/ggd.py
@@ -30,7 +30,7 @@ SUPPORTED_IDS_NAMES = (
 
 
 # Helper functions
-def multi_validator(*ids_names):
+def multi_validator(ids_names):
     """Decorator to apply the @validator decorator for multiple IDSs."""
 
     def decorator(func):
@@ -162,21 +162,21 @@ def get_filled_ggd_arrays(ids):
 
 
 # Grid rules
-@multi_validator(*SUPPORTED_IDS_NAMES)
+@multi_validator(SUPPORTED_IDS_NAMES)
 def validate_grid_ggd_identifier(ids):
     """Validate that the identifiers of all grid_ggds are filled."""
     for grid_ggd in ids.grid_ggd:
         assert_identifier_filled(grid_ggd.identifier)
 
 
-@multi_validator(*SUPPORTED_IDS_NAMES)
+@multi_validator(SUPPORTED_IDS_NAMES)
 def validate_grid_ggd_length(ids):
     """Validate that the number of structures in the grid_ggd AoS match
     the number of time steps."""
     assert len(ids.grid_ggd) == len(ids.time)
 
 
-@multi_validator(*SUPPORTED_IDS_NAMES)
+@multi_validator(SUPPORTED_IDS_NAMES)
 def validate_grid_ggd_time_homogeneous(ids):
     """Validate that there if the IDS has homogeneous time,
     the time nodes in the individual grid_ggd structures are not filled."""
@@ -186,7 +186,7 @@ def validate_grid_ggd_time_homogeneous(ids):
 
 
 # Space rules
-@multi_validator(*SUPPORTED_IDS_NAMES)
+@multi_validator(SUPPORTED_IDS_NAMES)
 def validate_space_identifier(ids):
     """Validate that the identifiers of all grid_ggd spaces are filled"""
     for grid_ggd in ids.grid_ggd:
@@ -194,7 +194,7 @@ def validate_space_identifier(ids):
             assert_identifier_filled(space.identifier)
 
 
-@multi_validator(*SUPPORTED_IDS_NAMES)
+@multi_validator(SUPPORTED_IDS_NAMES)
 def validate_space_coordinates_type_identifier(ids):
     """Validate that the space.coordinate_types match with ones that
     are in the coordinate identifier reference list."""
@@ -206,7 +206,7 @@ def validate_space_coordinates_type_identifier(ids):
                 )
 
 
-@multi_validator(*SUPPORTED_IDS_NAMES)
+@multi_validator(SUPPORTED_IDS_NAMES)
 def validate_space_geometry_type_identifier(ids):
     """Validate that the geometry_type of all spaces is at least 0
     (0 standard, 1 fourier, >1 fourier with periodicity)"""
@@ -216,7 +216,7 @@ def validate_space_geometry_type_identifier(ids):
 
 
 # Objects_per_dimension rules
-@multi_validator(*SUPPORTED_IDS_NAMES)
+@multi_validator(SUPPORTED_IDS_NAMES)
 def validate_obj_per_dim_geometry_content(ids):
     """Validate that if the geometry_content is filled, its values match
     the reference ggd_geometry_content_identifier."""
@@ -238,7 +238,7 @@ def validate_obj_per_dim_geometry_content(ids):
                         )
 
 
-@multi_validator(*SUPPORTED_IDS_NAMES)
+@multi_validator(SUPPORTED_IDS_NAMES)
 def validate_obj_per_dim_geometry_length(ids):
     """Validate that the geometry of the objects have the correct length, according to
     its geometry_content."""
@@ -273,7 +273,7 @@ def validate_obj_per_dim_geometry_length(ids):
                             assert len(geometry) == len(space.coordinates_type)
 
 
-@multi_validator(*SUPPORTED_IDS_NAMES)
+@multi_validator(SUPPORTED_IDS_NAMES)
 def validate_obj_0D_geometry_length(ids):
     """Validate that the geometry of 0D objects is larger than zero."""
     for grid_ggd in ids.grid_ggd:
@@ -283,7 +283,7 @@ def validate_obj_0D_geometry_length(ids):
                 assert len(obj.geometry) > 0
 
 
-@multi_validator(*SUPPORTED_IDS_NAMES)
+@multi_validator(SUPPORTED_IDS_NAMES)
 def validate_obj_per_dim_nodes_length(ids):
     """Validate that the nodes of the objects have the correct length.
     0D objects should be empty or contain themselves, edges should contain 2
@@ -302,7 +302,7 @@ def validate_obj_per_dim_nodes_length(ids):
                         assert len(nodes) >= dim + 1
 
 
-@multi_validator(*SUPPORTED_IDS_NAMES)
+@multi_validator(SUPPORTED_IDS_NAMES)
 def validate_obj_per_dim_nodes(ids):
     """Validate that the filled nodes of an object point to
     existing nodes in the grid."""
@@ -316,7 +316,7 @@ def validate_obj_per_dim_nodes(ids):
                             assert node <= len_0D_obj
 
 
-@multi_validator(*SUPPORTED_IDS_NAMES)
+@multi_validator(SUPPORTED_IDS_NAMES)
 def validate_obj_per_dim_measure_empty(ids):
     """Validate that the measure value of 0D objects is empty."""
     for grid_ggd in ids.grid_ggd:
@@ -327,7 +327,7 @@ def validate_obj_per_dim_measure_empty(ids):
 
 
 # Grid subset rules
-@multi_validator(*SUPPORTED_IDS_NAMES)
+@multi_validator(SUPPORTED_IDS_NAMES)
 def validate_grid_subset_identifier(ids):
     """Validate that grid subset identifier is filled."""
     for grid_ggd in ids.grid_ggd:
@@ -335,14 +335,14 @@ def validate_grid_subset_identifier(ids):
             assert_identifier_filled(grid_subset.identifier)
 
 
-@multi_validator(*SUPPORTED_IDS_NAMES)
+@multi_validator(SUPPORTED_IDS_NAMES)
 def validate_grid_subset_length(ids):
     """Validate that the grid has at least 1 grid subset."""
     for grid_ggd in ids.grid_ggd:
         assert len(grid_ggd.grid_subset) > 0
 
 
-@multi_validator(*SUPPORTED_IDS_NAMES)
+@multi_validator(SUPPORTED_IDS_NAMES)
 def validate_grid_subset_space_index(ids):
     """Validate that the space in the subset points to an existing space in the grid."""
     for grid_ggd in ids.grid_ggd:
@@ -353,7 +353,7 @@ def validate_grid_subset_space_index(ids):
                     assert_index_in_aos_identifier(grid_ggd.space, space_idx)
 
 
-@multi_validator(*SUPPORTED_IDS_NAMES)
+@multi_validator(SUPPORTED_IDS_NAMES)
 def validate_grid_subset_dimension_index(ids):
     """Validate that the dimension in the grid subset points to
     an existing dimension in the grid."""
@@ -367,7 +367,7 @@ def validate_grid_subset_dimension_index(ids):
                     assert len(space.objects_per_dimension) >= dim
 
 
-@multi_validator(*SUPPORTED_IDS_NAMES)
+@multi_validator(SUPPORTED_IDS_NAMES)
 def validate_grid_subset_object_index(ids):
     """Validate that the object index in the grid subset points to an existing
     object in the grid."""
@@ -384,7 +384,7 @@ def validate_grid_subset_object_index(ids):
                     )
 
 
-@multi_validator(*SUPPORTED_IDS_NAMES)
+@multi_validator(SUPPORTED_IDS_NAMES)
 def validate_grid_subset_obj_dimension(ids):
     """Validate that the dimensions of the objects of which a grid subset is composed
     are not larger than the dimension of the grid subset itself."""
@@ -398,7 +398,7 @@ def validate_grid_subset_obj_dimension(ids):
 
 
 # GGD rules
-@multi_validator(*SUPPORTED_IDS_NAMES)
+@multi_validator(SUPPORTED_IDS_NAMES)
 def validate_ggd_length(ids):
     """Validate that the dimensions of the GGD AoS
     matches the number of time steps."""
@@ -407,7 +407,7 @@ def validate_ggd_length(ids):
         assert len(ggd_aos) == len(ids.time)
 
 
-@multi_validator(*SUPPORTED_IDS_NAMES)
+@multi_validator(SUPPORTED_IDS_NAMES)
 def validate_ggd_time_homogeneous(ids):
     """Validate that if the IDS has homogeneous time,
     the time nodes of the individual GGD structures are not filled."""
@@ -419,7 +419,7 @@ def validate_ggd_time_homogeneous(ids):
 
 
 # GGD array rules
-@multi_validator(*SUPPORTED_IDS_NAMES)
+@multi_validator(SUPPORTED_IDS_NAMES)
 def validate_ggd_array_match_element(ids):
     """Validate that the number of values in a GGD array match the number of elements
     in the corresponding subset. If the subset contains all nodes by
@@ -448,7 +448,7 @@ def validate_ggd_array_match_element(ids):
                         assert len(grid_subset.element) == len(quantity)
 
 
-@multi_validator(*SUPPORTED_IDS_NAMES)
+@multi_validator(SUPPORTED_IDS_NAMES)
 def validate_ggd_array_filled_indices(ids):
     """Validate that all GGD arrays have filled grid_index and grid_subset_index."""
     scalar_arrays, vector_arrays = get_filled_ggd_arrays(ids)
@@ -458,7 +458,7 @@ def validate_ggd_array_filled_indices(ids):
             assert sub_array.grid_subset_index.has_value
 
 
-@multi_validator(*SUPPORTED_IDS_NAMES)
+@multi_validator(SUPPORTED_IDS_NAMES)
 def validate_ggd_array_valid_grid_index(ids):
     """Validate that for the grid_index of a GGD array, the
     identifier index of the corresponding grid_ggd matches.
@@ -472,7 +472,7 @@ def validate_ggd_array_valid_grid_index(ids):
             assert grid_index == grid_ggd_index
 
 
-@multi_validator(*SUPPORTED_IDS_NAMES)
+@multi_validator(SUPPORTED_IDS_NAMES)
 def validate_ggd_array_valid_grid_subset_index(ids):
     """Validate that the grid_subset_index of a GGD array matches
     with the identifier index of a grid subset.
@@ -487,7 +487,7 @@ def validate_ggd_array_valid_grid_subset_index(ids):
             )
 
 
-@multi_validator(*SUPPORTED_IDS_NAMES)
+@multi_validator(SUPPORTED_IDS_NAMES)
 def validate_ggd_array_labels_filled(ids):
     """Validate that the labels of ions/neutrals are filled."""
     ggd_list = get_ggd_aos(ids)

--- a/ids_validator/assets/rulesets/generic/ggd.py
+++ b/ids_validator/assets/rulesets/generic/ggd.py
@@ -317,7 +317,8 @@ def validate_obj_per_dim_nodes(ids):
             for obj_per_dim in space.objects_per_dimension:
                 for obj in obj_per_dim.object:
                     if obj.nodes.has_value:
-                        assert 0 < obj.nodes <= len_0D_obj
+                        assert (0 < obj.nodes).all()
+                        assert (obj.nodes <= len_0D_obj).all()
 
 
 @multi_validator(SUPPORTED_IDS_NAMES)

--- a/ids_validator/assets/rulesets/generic/ggd.py
+++ b/ids_validator/assets/rulesets/generic/ggd.py
@@ -30,8 +30,11 @@ SUPPORTED_IDS_NAMES = (
 
 
 # Helper functions
-def assert_homogeneous_time_mode(ids):
-    assert ids.ids_properties.homogeneous_time == IDS_TIME_MODE_HOMOGENEOUS
+def has_homogeneous_time(ids):
+    if ids.ids_properties.homogeneous_time == IDS_TIME_MODE_HOMOGENEOUS:
+        return True
+    else:
+        return False
 
 
 def multi_validator(ids_names):
@@ -139,7 +142,8 @@ def get_filled_ggd_arrays(ids):
 @multi_validator(SUPPORTED_IDS_NAMES)
 def validate_grid_ggd_identifier(ids):
     """Validate that the identifiers of all grid_ggds are filled."""
-    assert_homogeneous_time_mode(ids)
+    if not has_homogeneous_time(ids):
+        return
     for grid_ggd in ids.grid_ggd:
         assert_identifier_filled(grid_ggd.identifier)
 
@@ -148,7 +152,8 @@ def validate_grid_ggd_identifier(ids):
 def validate_grid_ggd_length(ids):
     """Validate that the number of structures in the grid_ggd AoS match
     the number of time steps."""
-    assert_homogeneous_time_mode(ids)
+    if not has_homogeneous_time(ids):
+        return
     assert len(ids.grid_ggd) == len(ids.time)
 
 
@@ -156,7 +161,8 @@ def validate_grid_ggd_length(ids):
 def validate_grid_ggd_time_homogeneous(ids):
     """Validate that if the IDS has homogeneous time,
     the time nodes in the individual grid_ggd structures are not filled."""
-    assert_homogeneous_time_mode(ids)
+    if not has_homogeneous_time(ids):
+        return
     for grid_ggd in ids.grid_ggd:
         assert not grid_ggd.time.has_value
 
@@ -165,7 +171,8 @@ def validate_grid_ggd_time_homogeneous(ids):
 @multi_validator(SUPPORTED_IDS_NAMES)
 def validate_space_identifier(ids):
     """Validate that the identifiers of all grid_ggd spaces are filled"""
-    assert_homogeneous_time_mode(ids)
+    if not has_homogeneous_time(ids):
+        return
     for grid_ggd in ids.grid_ggd:
         for space in grid_ggd.space:
             assert_identifier_filled(space.identifier)
@@ -175,7 +182,8 @@ def validate_space_identifier(ids):
 def validate_space_coordinates_type_identifier(ids):
     """Validate that the space.coordinate_types match with ones that
     are in the coordinate identifier reference list."""
-    assert_homogeneous_time_mode(ids)
+    if not has_homogeneous_time(ids):
+        return
     for grid_ggd in ids.grid_ggd:
         for space in grid_ggd.space:
             for coord_type in space.coordinates_type:
@@ -188,7 +196,8 @@ def validate_space_coordinates_type_identifier(ids):
 def validate_space_geometry_type_identifier(ids):
     """Validate that the geometry_type of all spaces is at least 0
     (0 standard, 1 fourier, >1 fourier with periodicity)"""
-    assert_homogeneous_time_mode(ids)
+    if not has_homogeneous_time(ids):
+        return
     for grid_ggd in ids.grid_ggd:
         for space in grid_ggd.space:
             assert space.geometry_type.index >= 0
@@ -199,7 +208,8 @@ def validate_space_geometry_type_identifier(ids):
 def validate_obj_per_dim_geometry_content(ids):
     """Validate that if the geometry_content is filled, its values match
     the reference ggd_geometry_content_identifier."""
-    assert_homogeneous_time_mode(ids)
+    if not has_homogeneous_time(ids):
+        return
     for grid_ggd in ids.grid_ggd:
         for space in grid_ggd.space:
             for dim, obj_per_dim in enumerate(space.objects_per_dimension):
@@ -227,7 +237,8 @@ def validate_obj_per_dim_geometry_content(ids):
 def validate_obj_per_dim_geometry_length(ids):
     """Validate that the geometry of the objects have the correct length, according to
     its geometry_content."""
-    assert_homogeneous_time_mode(ids)
+    if not has_homogeneous_time(ids):
+        return
     for grid_ggd in ids.grid_ggd:
         for space in grid_ggd.space:
             for dim, obj_per_dim in enumerate(space.objects_per_dimension):
@@ -262,7 +273,8 @@ def validate_obj_per_dim_geometry_length(ids):
 @multi_validator(SUPPORTED_IDS_NAMES)
 def validate_obj_0D_geometry_length(ids):
     """Validate that the geometry of 0D objects is larger than zero."""
-    assert_homogeneous_time_mode(ids)
+    if not has_homogeneous_time(ids):
+        return
     for grid_ggd in ids.grid_ggd:
         for space in grid_ggd.space:
             obj_0D = space.objects_per_dimension[0]
@@ -275,7 +287,8 @@ def validate_obj_per_dim_nodes_length(ids):
     """Validate that the nodes of the objects have the correct length.
     0D objects should be empty or contain themselves, edges should contain 2
     nodes, while n-order should contain at least n+1 nodes."""
-    assert_homogeneous_time_mode(ids)
+    if not has_homogeneous_time(ids):
+        return
     for grid_ggd in ids.grid_ggd:
         for space in grid_ggd.space:
             for dim, obj_per_dim in enumerate(space.objects_per_dimension):
@@ -294,7 +307,8 @@ def validate_obj_per_dim_nodes_length(ids):
 def validate_obj_per_dim_nodes(ids):
     """Validate that the filled nodes of an object point to
     existing nodes in the grid."""
-    assert_homogeneous_time_mode(ids)
+    if not has_homogeneous_time(ids):
+        return
     for grid_ggd in ids.grid_ggd:
         for space in grid_ggd.space:
             len_0D_obj = len(space.objects_per_dimension[0].object)
@@ -308,7 +322,8 @@ def validate_obj_per_dim_nodes(ids):
 @multi_validator(SUPPORTED_IDS_NAMES)
 def validate_obj_per_dim_measure_empty(ids):
     """Validate that the measure value of 0D objects is empty."""
-    assert_homogeneous_time_mode(ids)
+    if not has_homogeneous_time(ids):
+        return
     for grid_ggd in ids.grid_ggd:
         for space in grid_ggd.space:
             obj_0D = space.objects_per_dimension[0]
@@ -320,7 +335,8 @@ def validate_obj_per_dim_measure_empty(ids):
 @multi_validator(SUPPORTED_IDS_NAMES)
 def validate_grid_subset_identifier(ids):
     """Validate that grid subset identifier is filled."""
-    assert_homogeneous_time_mode(ids)
+    if not has_homogeneous_time(ids):
+        return
     for grid_ggd in ids.grid_ggd:
         for grid_subset in grid_ggd.grid_subset:
             assert_identifier_filled(grid_subset.identifier)
@@ -329,7 +345,8 @@ def validate_grid_subset_identifier(ids):
 @multi_validator(SUPPORTED_IDS_NAMES)
 def validate_grid_subset_length(ids):
     """Validate that the grid has at least 1 grid subset."""
-    assert_homogeneous_time_mode(ids)
+    if not has_homogeneous_time(ids):
+        return
     for grid_ggd in ids.grid_ggd:
         assert len(grid_ggd.grid_subset) > 0
 
@@ -337,7 +354,8 @@ def validate_grid_subset_length(ids):
 @multi_validator(SUPPORTED_IDS_NAMES)
 def validate_grid_subset_space_index(ids):
     """Validate that the space in the subset points to an existing space in the grid."""
-    assert_homogeneous_time_mode(ids)
+    if not has_homogeneous_time(ids):
+        return
     for grid_ggd in ids.grid_ggd:
         for grid_subset in grid_ggd.grid_subset:
             for element in grid_subset.element:
@@ -350,7 +368,8 @@ def validate_grid_subset_space_index(ids):
 def validate_grid_subset_dimension_index(ids):
     """Validate that the dimension in the grid subset points to
     an existing dimension in the grid."""
-    assert_homogeneous_time_mode(ids)
+    if not has_homogeneous_time(ids):
+        return
     for grid_ggd in ids.grid_ggd:
         for grid_subset in grid_ggd.grid_subset:
             for element in grid_subset.element:
@@ -365,7 +384,8 @@ def validate_grid_subset_dimension_index(ids):
 def validate_grid_subset_object_index(ids):
     """Validate that the object index in the grid subset points to an existing
     object in the grid."""
-    assert_homogeneous_time_mode(ids)
+    if not has_homogeneous_time(ids):
+        return
     for grid_ggd in ids.grid_ggd:
         for grid_subset in grid_ggd.grid_subset:
             for element in grid_subset.element:
@@ -383,7 +403,8 @@ def validate_grid_subset_object_index(ids):
 def validate_grid_subset_obj_dimension(ids):
     """Validate that the dimensions of the objects of which a grid subset is composed
     are not larger than the dimension of the grid subset itself."""
-    assert_homogeneous_time_mode(ids)
+    if not has_homogeneous_time(ids):
+        return
     for grid_ggd in ids.grid_ggd:
         for grid_subset in grid_ggd.grid_subset:
             subset_dim = grid_subset.dimension
@@ -398,7 +419,8 @@ def validate_grid_subset_obj_dimension(ids):
 def validate_ggd_length(ids):
     """Validate that the dimensions of the GGD AoS
     matches the number of time steps."""
-    assert_homogeneous_time_mode(ids)
+    if not has_homogeneous_time(ids):
+        return
     ggd_list = get_ggd_aos(ids)
     for ggd_aos in ggd_list:
         assert len(ggd_aos) == len(ids.time)
@@ -408,7 +430,8 @@ def validate_ggd_length(ids):
 def validate_ggd_time_homogeneous(ids):
     """Validate that if the IDS has homogeneous time,
     the time nodes of the individual GGD structures are not filled."""
-    assert_homogeneous_time_mode(ids)
+    if not has_homogeneous_time(ids):
+        return
     ggd_list = get_ggd_aos(ids)
     for ggd_aos in ggd_list:
         for ggd in ggd_aos:
@@ -423,7 +446,8 @@ def validate_ggd_array_match_element(ids):
     definition, which occurs for the ggd subsets named 'nodes', 'edges', 'cells' and
     'volumes' in the reference identifier, the elements can be left empty.
     """
-    assert_homogeneous_time_mode(ids)
+    if not has_homogeneous_time(ids):
+        return
     scalar_arrays, vector_arrays = get_filled_ggd_arrays(ids)
     for array in scalar_arrays + vector_arrays:
         for sub_array in array:
@@ -454,7 +478,8 @@ def validate_ggd_array_valid_grid_index(ids):
     """Validate that for the grid_index of a GGD array, the
     identifier index of the corresponding grid_ggd matches.
     """
-    assert_homogeneous_time_mode(ids)
+    if not has_homogeneous_time(ids):
+        return
     scalar_arrays, vector_arrays = get_filled_ggd_arrays(ids)
     for array in scalar_arrays + vector_arrays:
         for sub_array in array:
@@ -470,7 +495,8 @@ def validate_ggd_array_valid_grid_subset_index(ids):
     """Validate that the grid_subset_index of a GGD array matches
     with the identifier index of a grid subset.
     """
-    assert_homogeneous_time_mode(ids)
+    if not has_homogeneous_time(ids):
+        return
     scalar_arrays, vector_arrays = get_filled_ggd_arrays(ids)
     for array in scalar_arrays + vector_arrays:
         for sub_array in array:
@@ -486,6 +512,7 @@ def validate_ggd_array_valid_grid_subset_index(ids):
 @multi_validator(SUPPORTED_IDS_NAMES)
 def validate_ggd_array_labels_filled(ids):
     """Validate that the labels of ions/neutrals are filled."""
-    assert_homogeneous_time_mode(ids)
+    if not has_homogeneous_time(ids):
+        return
     for label in Select(ids, "/label$"):
         assert label.has_value

--- a/ids_validator/assets/rulesets/generic/ggd.py
+++ b/ids_validator/assets/rulesets/generic/ggd.py
@@ -136,7 +136,7 @@ def recursive_label_search(ggd, label_list):
     """Recursively searches through a GGD structure for quantities which
     have the metadata name 'label', and appends these to the given label_list."""
     for node in ggd:
-        if node.metadata.name == "label":
+        if node.metadata.name == "label" or node.metadata.name == "name":
             label_list.append(node)
         if (
             node.metadata.data_type == IDSDataType.STRUCTURE

--- a/ids_validator/assets/rulesets/generic/ggd.py
+++ b/ids_validator/assets/rulesets/generic/ggd.py
@@ -1,6 +1,8 @@
 """Rules applying to all IDSs containing GGDs"""
+
 from imaspy.ids_defs import IDS_TIME_MODE_HOMOGENEOUS
 from imaspy import identifiers
+import imaspy
 
 SUPPORTED_IDS_NAMES = (
     "edge_profiles",
@@ -12,14 +14,26 @@ SUPPORTED_IDS_NAMES = (
     "wall",
 )
 
-EXPERIMENTAL_IDS_NAMES = [
-    "equilibrium",
-    "distribution_sources",
-    "distributions",
-    "tf",
-    "transport_solver_numerics",
-    "waves",
-]
+#   EXPERIMENTAL_IDS_NAMES = [
+#       "equilibrium",
+#       "distribution_sources",
+#       "distributions",
+#       "tf",
+#       "transport_solver_numerics",
+#       "waves",
+#   ]
+
+def get_ggd(ids):
+    """Get all GGD base nodes"""
+    ggd_list = []
+    for node in Select(ids,"(^|/)ggd$", leaf_only=False):
+        if node.metadata.name == "ggd":
+            parent_node = imaspy.util.get_parent(node._obj)
+            if parent_node.metadata.name != "ggd":
+                ggd_list.append(node)
+    return ggd_list
+
+
 
 def validate_identifier(identifier):
     """Validate that an identifier has its name, index and description filled"""
@@ -27,23 +41,28 @@ def validate_identifier(identifier):
     assert identifier.index.has_value
     assert identifier.description.has_value
 
+
 def is_index_in_identifiers(index, identifier_list):
     """Checks if an index appears in an identifier list"""
     return any(index == member.value for member in identifier_list)
 
+
 # TODO: only test on GGD IDS instead of all
 
-# Grid rules 
+
+# Grid rules
 @validator("*")
 def validate_grid_ggd_identifier(ids):
     """Validate that the identifiers of all grid_ggds are filled"""
     for grid_ggd in ids.grid_ggd:
         validate_identifier(grid_ggd.identifier)
 
+
 @validator("*")
 def validate_grid_ggd_length(ids):
     """Validate that there are as many grids as there are time steps"""
     assert len(ids.grid_ggd) == len(ids.time)
+
 
 @validator("*")
 def validate_grid_ggd_time_homogeneous(ids):
@@ -51,6 +70,7 @@ def validate_grid_ggd_time_homogeneous(ids):
     if ids.ids_properties.homogeneous_time == IDS_TIME_MODE_HOMOGENEOUS:
         for grid_ggd in ids.grid_ggd:
             assert not grid_ggd.time.has_value
+
 
 # Space rules
 @validator("*")
@@ -60,13 +80,17 @@ def validate_space_identifier(ids):
         for space in grid_ggd.space:
             validate_identifier(space.identifier)
 
+
 @validator("*")
 def validate_space_coordinates_type_identifier(ids):
     """Validate that the coordinate type identifiers match"""
     for grid_ggd in ids.grid_ggd:
         for space in grid_ggd.space:
             for coord_type in space.coordinates_type:
-                assert is_index_in_identifiers(coord_type, identifiers.coordinate_identifier)
+                assert is_index_in_identifiers(
+                    coord_type, identifiers.coordinate_identifier
+                )
+
 
 @validator("*")
 def validate_space_geometry_type_identifier(ids):
@@ -75,6 +99,7 @@ def validate_space_geometry_type_identifier(ids):
     for grid_ggd in ids.grid_ggd:
         for space in grid_ggd.space:
             assert space.geometry_type.index >= 0
+
 
 # Objects_per_dimension rules
 @validator("*")
@@ -92,11 +117,14 @@ def validate_obj_per_dim_geometry_content(ids):
                     elif dim == 2:
                         assert geometry_content in {31, 32}
                     else:
-                        assert False, "Geometry content undefined for n-dimensional objects with n>2"
+                        assert (
+                            False
+                        ), "Geometry content undefined for n-dimensional objects with n>2"
+
 
 @validator("*")
 def validate_obj_per_dim_geometry_length(ids):
-    """Validate that the geometry of the objects have the correct length, according to 
+    """Validate that the geometry of the objects have the correct length, according to
     its geometry_content"""
     for grid_ggd in ids.grid_ggd:
         for space in grid_ggd.space:
@@ -116,4 +144,144 @@ def validate_obj_per_dim_geometry_length(ids):
                         elif geometry_content == 32:
                             assert len(geometry) == 5
                     else:
-                        assert len(geometry) == len(space.coordinates_type)
+                        if geometry.has_value:
+                            assert len(geometry) == len(space.coordinates_type)
+
+
+@validator("*")
+def validate_obj_0D_geometry_length(ids):
+    """Validate that the geometry of 0D objects is larger than zero."""
+    for grid_ggd in ids.grid_ggd:
+        for space in grid_ggd.space:
+            obj_0D = space.objects_per_dimension[0]
+            for obj in obj_0D.object:
+                assert len(obj.geometry) > 0
+
+
+@validator("*")
+def validate_obj_per_dim_nodes_length(ids):
+    """Validate that the nodes of the objects have the correct length. 
+    0D objects should be empty or contain themselves, edges should contain 2 
+    nodes, while n-order should contain at least n+1 nodes."""
+    for grid_ggd in ids.grid_ggd:
+        for space in grid_ggd.space:
+            for dim, obj_per_dim in enumerate(space.objects_per_dimension):
+                for i, obj in enumerate(obj_per_dim.object):
+                    nodes = obj.nodes
+                    if dim == 0:
+                        if nodes.has_value:
+                            assert nodes == [i + 1]
+                    elif dim == 1:
+                        assert len(nodes) == 2
+                    else:
+                        assert len(nodes) >= dim + 1
+
+@validator("*")
+def validate_obj_per_dim_nodes(ids):
+    """Validate that the filled object nodes point to existing nodes in the grid."""
+    for grid_ggd in ids.grid_ggd:
+        for space in grid_ggd.space:
+            len_0D_obj = len(space.objects_per_dimension[0].object)
+            for obj_per_dim in space.objects_per_dimension:
+                for obj in obj_per_dim.object:
+                    if obj.nodes.has_value:
+                        for node in obj.nodes:
+                            assert node <= len_0D_obj
+
+@validator("*")
+def validate_obj_per_dim_measure_empty(ids):
+    """Validate that the measure value of 0D objects is empty."""
+    for grid_ggd in ids.grid_ggd:
+        for space in grid_ggd.space:
+            obj_0D = space.objects_per_dimension[0]
+            for obj in obj_0D.object:
+                assert not obj.measure.has_value
+
+
+# Grid subset rules
+@validator("*")
+def validate_grid_subset_identifier(ids):
+    """Validate the grid subset identifier."""
+    for grid_ggd in ids.grid_ggd:
+        for grid_subset in grid_ggd.grid_subset:
+            validate_identifier(grid_subset.identifier)
+
+
+@validator("*")
+def validate_grid_subset_length(ids):
+    """Validate that the grid has at least 1 grid subset."""
+    for grid_ggd in ids.grid_ggd:
+        assert len(grid_ggd.grid_subset) > 0
+
+
+def is_index_in_aos_identifier(aos, index):
+    """Check if an index appears exactly once in the identifier of an AoS."""
+    matches = sum(
+        1 for structure in aos if structure.identifier.index == index
+    )
+    assert matches == 1
+
+def find_index_match_in_aos_identifier(aos, index):
+    """Return the first object in 'aos' whose identifier.index matches the given index, or None if no match is found."""
+    for structure in aos:
+        if structure.identifier.index == index:
+            return structure
+    return None 
+
+@validator("*")
+def validate_grid_subset_space_index(ids):
+    """Validate that the space in the subset points to an existing space in the grid."""
+    for grid_ggd in ids.grid_ggd:
+        for grid_subset in grid_ggd.grid_subset:
+            for element in grid_subset.element:
+                for object in element.object:
+                    space_idx = object.space
+                    is_index_in_aos_identifier(grid_ggd.space, space_idx)
+
+@validator("*")
+def validate_grid_subset_dimension_index(ids):
+    """Validate that the dimension in the subset points to an existing dimension in the grid."""
+    for grid_ggd in ids.grid_ggd:
+        for grid_subset in grid_ggd.grid_subset:
+            for element in grid_subset.element:
+                for object in element.object:
+                    dim = object.dimension
+                    space_idx = object.space
+                    space = find_index_match_in_aos_identifier(grid_ggd.space, space_idx)
+                    assert len(space.objects_per_dimension) >= dim
+
+
+@validator("*")
+def validate_grid_subset_object_index(ids):
+    """Validate that the object index in the subset points to an existing object in the grid."""
+    for grid_ggd in ids.grid_ggd:
+        for grid_subset in grid_ggd.grid_subset:
+            for element in grid_subset.element:
+                for object in element.object:
+                    dim = object.dimension
+                    space_idx = object.space
+                    obj_idx = object.index
+                    space = find_index_match_in_aos_identifier(grid_ggd.space, space_idx)
+                    assert (
+                        len(space.objects_per_dimension[dim._obj - 1].object) >= obj_idx
+                    )
+
+
+@validator("*")
+def validate_grid_subset_obj_dimension(ids):
+    """Validate that the dimensions of the object are not larger than the object of the grid subset."""
+    for grid_ggd in ids.grid_ggd:
+        for grid_subset in grid_ggd.grid_subset:
+            subset_dim = grid_subset.dimension
+            for element in grid_subset.element:
+                for object in element.object:
+                    obj_dim = object.dimension
+                    assert subset_dim >= obj_dim
+
+# GGD rules                    
+@validator("*")
+def validate_ggd_length(ids):
+    """Validate that the dimensions of the GGD match the number of time steps."""
+    ggd_list = get_ggd(ids)
+    for ggd in ggd_list:
+        assert len(ggd) == len(ids.time)

--- a/ids_validator/assets/rulesets/generic/ggd.py
+++ b/ids_validator/assets/rulesets/generic/ggd.py
@@ -390,9 +390,7 @@ def validate_grid_subset_object_index(ids):
                     obj_idx = object.index
                     space = find_structure_by_index(grid_ggd.space, space_idx)
                     assert (
-                        len(space.objects_per_dimension[dim._obj - 1].object)
-                        >= obj_idx
-                        > 0
+                        len(space.objects_per_dimension[dim - 1].object) >= obj_idx > 0
                     )
 
 

--- a/ids_validator/assets/rulesets/generic/ggd.py
+++ b/ids_validator/assets/rulesets/generic/ggd.py
@@ -143,7 +143,7 @@ def get_filled_ggd_arrays(ids):
         for ggd in ggd_aos:
 
             recursive_ggd_path_search(
-                ggd._obj,
+                ggd,
                 scalar_arrays,
                 vector_arrays,
             )

--- a/ids_validator/assets/rulesets/generic/ggd.py
+++ b/ids_validator/assets/rulesets/generic/ggd.py
@@ -1,0 +1,119 @@
+"""Rules applying to all IDSs containing GGDs"""
+from imaspy.ids_defs import IDS_TIME_MODE_HOMOGENEOUS
+from imaspy import identifiers
+
+SUPPORTED_IDS_NAMES = (
+    "edge_profiles",
+    "edge_sources",
+    "edge_transport",
+    "mhd",
+    "radiation",
+    "runaway_electrons",
+    "wall",
+)
+
+EXPERIMENTAL_IDS_NAMES = [
+    "equilibrium",
+    "distribution_sources",
+    "distributions",
+    "tf",
+    "transport_solver_numerics",
+    "waves",
+]
+
+def validate_identifier(identifier):
+    """Validate that an identifier has its name, index and description filled"""
+    assert identifier.name.has_value
+    assert identifier.index.has_value
+    assert identifier.description.has_value
+
+def is_index_in_identifiers(index, identifier_list):
+    """Checks if an index appears in an identifier list"""
+    return any(index == member.value for member in identifier_list)
+
+# TODO: only test on GGD IDS instead of all
+
+# Grid rules 
+@validator("*")
+def validate_grid_ggd_identifier(ids):
+    """Validate that the identifiers of all grid_ggds are filled"""
+    for grid_ggd in ids.grid_ggd:
+        validate_identifier(grid_ggd.identifier)
+
+@validator("*")
+def validate_grid_ggd_length(ids):
+    """Validate that there are as many grids as there are time steps"""
+    assert len(ids.grid_ggd) == len(ids.time)
+
+@validator("*")
+def validate_grid_ggd_time_homogeneous(ids):
+    """Validate that there if the IDS has homogeneous time, the individual grid_ggd time nodes are not filled."""
+    if ids.ids_properties.homogeneous_time == IDS_TIME_MODE_HOMOGENEOUS:
+        for grid_ggd in ids.grid_ggd:
+            assert not grid_ggd.time.has_value
+
+# Space rules
+@validator("*")
+def validate_space_identifier(ids):
+    """Validate that the identifiers of all grid_ggd spaces are filled"""
+    for grid_ggd in ids.grid_ggd:
+        for space in grid_ggd.space:
+            validate_identifier(space.identifier)
+
+@validator("*")
+def validate_space_coordinates_type_identifier(ids):
+    """Validate that the coordinate type identifiers match"""
+    for grid_ggd in ids.grid_ggd:
+        for space in grid_ggd.space:
+            for coord_type in space.coordinates_type:
+                assert is_index_in_identifiers(coord_type, identifiers.coordinate_identifier)
+
+@validator("*")
+def validate_space_geometry_type_identifier(ids):
+    """Validate that the geometry_type is at least 0
+    (0 standard, 1 fourier, >1 fourier with periodicity)"""
+    for grid_ggd in ids.grid_ggd:
+        for space in grid_ggd.space:
+            assert space.geometry_type.index >= 0
+
+# Objects_per_dimension rules
+@validator("*")
+def validate_obj_per_dim_geometry_content(ids):
+    """Validate that the geometry_content match the ggd_geometry_content_identifier"""
+    for grid_ggd in ids.grid_ggd:
+        for space in grid_ggd.space:
+            for dim, obj_per_dim in enumerate(space.objects_per_dimension):
+                geometry_content = obj_per_dim.geometry_content
+                if geometry_content.has_value and geometry_content != 0:
+                    if dim == 0:
+                        assert geometry_content in {1, 11}
+                    elif dim == 1:
+                        assert geometry_content == 21
+                    elif dim == 2:
+                        assert geometry_content in {31, 32}
+                    else:
+                        assert False, "Geometry content undefined for n-dimensional objects with n>2"
+
+@validator("*")
+def validate_obj_per_dim_geometry_length(ids):
+    """Validate that the geometry of the objects have the correct length, according to 
+    its geometry_content"""
+    for grid_ggd in ids.grid_ggd:
+        for space in grid_ggd.space:
+            for obj_per_dim in space.objects_per_dimension:
+                geometry_content = obj_per_dim.geometry_content
+                for obj in obj_per_dim.object:
+                    geometry = obj.geometry
+                    if geometry_content.has_value and geometry_content != 0:
+                        if geometry_content == 1:
+                            assert len(geometry) == len(space.coordinates_type)
+                        elif geometry_content == 11:
+                            assert len(geometry) == len(space.coordinates_type) + 2
+                        elif geometry_content == 21:
+                            assert len(geometry) == 3
+                        elif geometry_content == 31:
+                            assert len(geometry) == 3
+                        elif geometry_content == 32:
+                            assert len(geometry) == 5
+                    else:
+                        assert len(geometry) == len(space.coordinates_type)

--- a/ids_validator/assets/rulesets/generic/ggd.py
+++ b/ids_validator/assets/rulesets/generic/ggd.py
@@ -30,18 +30,17 @@ SUPPORTED_IDS_NAMES = (
 
 
 # Helper functions
-def multi_validator(*names):
+def multi_validator(*ids_names):
     """Decorator to apply the @validator decorator for multiple IDSs."""
 
     def decorator(func):
-        for name in names:
+        for name in ids_names:
             func = validator(name)(func)
         return func
 
     return decorator
 
 
-# Assertion helper functions
 def assert_identifier_filled(identifier):
     """Asserts that an identifier has its name, index and description fields filled."""
     assert identifier.name.has_value

--- a/ids_validator/assets/rulesets/generic/ggd.py
+++ b/ids_validator/assets/rulesets/generic/ggd.py
@@ -119,11 +119,10 @@ def get_ggd_aos(ids):
     """Get a list containing all GGD AoS nodes in the IDS"""
     ggd_list = []
     for node in Select(ids, "(^|/)ggd$", leaf_only=False):
-        if node.metadata.name == "ggd":
-            parent_node = imaspy.util.get_parent(node._obj)
-            # Do not include structures of GGD, i.e. ggd[0]
-            if parent_node.metadata.name != "ggd":
-                ggd_list.append(node)
+        parent_node = Parent(node)
+        # Do not include structures of GGD, i.e. ggd[0]
+        if parent_node.metadata.name != "ggd":
+            ggd_list.append(node)
     return ggd_list
 
 

--- a/ids_validator/assets/rulesets/generic/ggd.py
+++ b/ids_validator/assets/rulesets/generic/ggd.py
@@ -444,17 +444,12 @@ def validate_ggd_array_match_element(ids):
                 raise ValueError(
                     f"Could not find a grid_index with index {grid_subset_index}"
                 )
-            # The identifiers corresponding to nodes (1), edges (2), cells (5),
-            # and volumes (43), contain all nodes by definition. Therefore,
-            # the elements corresponding to these grid subsets may be left empty.
-            if grid_subset.identifier.index not in [1, 2, 5, 43]:
-                for quantity in sub_array:
-                    if (
-                        quantity.has_value
-                        and quantity.metadata.name != "grid_index"
-                        and quantity.metadata.name != "grid_subset_index"
-                    ):
-                        assert len(grid_subset.element) == len(quantity)
+            for quantity in sub_array.iter_nonempty_():
+                if (
+                    quantity.metadata.name != "grid_index"
+                    and quantity.metadata.name != "grid_subset_index"
+                ):
+                    assert len(grid_subset.element) == len(quantity)
 
 
 @multi_validator(SUPPORTED_IDS_NAMES)

--- a/ids_validator/assets/rulesets/generic/ggd.py
+++ b/ids_validator/assets/rulesets/generic/ggd.py
@@ -80,31 +80,23 @@ def recursive_ggd_path_search(quantity, scalar_list, vector_list):
     (real & complex) and vector GGD arrays (regular and rphiz), and stores
     these in the scalar and vector lists, respectively.
     """
-    for subquantity in quantity:
+    for subquantity in quantity.iter_nonempty_():
         if subquantity.metadata.data_type == IDSDataType.STRUCT_ARRAY:
             # Get scalar and complex scalar array quantities
-            if (
-                subquantity.metadata.structure_reference
-                in [
-                    "generic_grid_scalar",
-                    "generic_grid_scalar_complex",
-                ]
-                and subquantity.has_value
-            ):
+            if subquantity.metadata.structure_reference in [
+                "generic_grid_scalar",
+                "generic_grid_scalar_complex",
+            ]:
                 scalar_list.append(subquantity)
 
             # Get vector and rzphi-vector array quantities
             # From DDv4 onward `generic_grid_vector_components_rzphi` will be
             # replaced by `generic_grid_vector_components_rphiz`
-            elif (
-                subquantity.metadata.structure_reference
-                in [
-                    "generic_grid_vector_components",
-                    "generic_grid_vector_components_rzphi",
-                    "generic_grid_vector_components_rphiz",
-                ]
-                and subquantity.has_value
-            ):
+            elif subquantity.metadata.structure_reference in [
+                "generic_grid_vector_components",
+                "generic_grid_vector_components_rzphi",
+                "generic_grid_vector_components_rphiz",
+            ]:
                 vector_list.append(subquantity)
 
         if subquantity.metadata.data_type == IDSDataType.STRUCTURE:

--- a/ids_validator/assets/rulesets/generic/ggd.py
+++ b/ids_validator/assets/rulesets/generic/ggd.py
@@ -475,17 +475,6 @@ def validate_ggd_array_match_element(ids):
 
 
 @multi_validator(SUPPORTED_IDS_NAMES)
-def validate_ggd_array_filled_indices(ids):
-    """Validate that all GGD arrays have filled grid_index and grid_subset_index."""
-    assert_homogeneous_time_mode(ids)
-    scalar_arrays, vector_arrays = get_filled_ggd_arrays(ids)
-    for array in scalar_arrays + vector_arrays:
-        for sub_array in array:
-            assert sub_array.grid_index.has_value
-            assert sub_array.grid_subset_index.has_value
-
-
-@multi_validator(SUPPORTED_IDS_NAMES)
 def validate_ggd_array_valid_grid_index(ids):
     """Validate that for the grid_index of a GGD array, the
     identifier index of the corresponding grid_ggd matches.
@@ -494,6 +483,7 @@ def validate_ggd_array_valid_grid_index(ids):
     scalar_arrays, vector_arrays = get_filled_ggd_arrays(ids)
     for array in scalar_arrays + vector_arrays:
         for sub_array in array:
+            assert sub_array.grid_index.has_value
             grid_index = sub_array.grid_index
             matching_grid_ggd = get_matching_grid_ggd(ids, sub_array)
             grid_ggd_index = matching_grid_ggd.identifier.index
@@ -509,6 +499,7 @@ def validate_ggd_array_valid_grid_subset_index(ids):
     scalar_arrays, vector_arrays = get_filled_ggd_arrays(ids)
     for array in scalar_arrays + vector_arrays:
         for sub_array in array:
+            assert sub_array.grid_subset_index.has_value
             grid_subset_index = sub_array.grid_subset_index
             matching_grid_ggd = get_matching_grid_ggd(ids, array)
             assert_index_in_aos_identifier(

--- a/ids_validator/assets/rulesets/generic/ggd.py
+++ b/ids_validator/assets/rulesets/generic/ggd.py
@@ -30,6 +30,10 @@ SUPPORTED_IDS_NAMES = (
 
 
 # Helper functions
+def assert_homogeneous_time_mode(ids):
+    assert ids.ids_properties.homogeneous_time == IDS_TIME_MODE_HOMOGENEOUS
+
+
 def multi_validator(ids_names):
     """Decorator to apply the @validator decorator for multiple IDSs."""
 
@@ -165,6 +169,7 @@ def get_filled_ggd_arrays(ids):
 @multi_validator(SUPPORTED_IDS_NAMES)
 def validate_grid_ggd_identifier(ids):
     """Validate that the identifiers of all grid_ggds are filled."""
+    assert_homogeneous_time_mode(ids)
     for grid_ggd in ids.grid_ggd:
         assert_identifier_filled(grid_ggd.identifier)
 
@@ -173,6 +178,7 @@ def validate_grid_ggd_identifier(ids):
 def validate_grid_ggd_length(ids):
     """Validate that the number of structures in the grid_ggd AoS match
     the number of time steps."""
+    assert_homogeneous_time_mode(ids)
     assert len(ids.grid_ggd) == len(ids.time)
 
 
@@ -180,15 +186,16 @@ def validate_grid_ggd_length(ids):
 def validate_grid_ggd_time_homogeneous(ids):
     """Validate that there if the IDS has homogeneous time,
     the time nodes in the individual grid_ggd structures are not filled."""
-    if ids.ids_properties.homogeneous_time == IDS_TIME_MODE_HOMOGENEOUS:
-        for grid_ggd in ids.grid_ggd:
-            assert not grid_ggd.time.has_value
+    assert_homogeneous_time_mode(ids)
+    for grid_ggd in ids.grid_ggd:
+        assert not grid_ggd.time.has_value
 
 
 # Space rules
 @multi_validator(SUPPORTED_IDS_NAMES)
 def validate_space_identifier(ids):
     """Validate that the identifiers of all grid_ggd spaces are filled"""
+    assert_homogeneous_time_mode(ids)
     for grid_ggd in ids.grid_ggd:
         for space in grid_ggd.space:
             assert_identifier_filled(space.identifier)
@@ -198,6 +205,7 @@ def validate_space_identifier(ids):
 def validate_space_coordinates_type_identifier(ids):
     """Validate that the space.coordinate_types match with ones that
     are in the coordinate identifier reference list."""
+    assert_homogeneous_time_mode(ids)
     for grid_ggd in ids.grid_ggd:
         for space in grid_ggd.space:
             for coord_type in space.coordinates_type:
@@ -210,6 +218,7 @@ def validate_space_coordinates_type_identifier(ids):
 def validate_space_geometry_type_identifier(ids):
     """Validate that the geometry_type of all spaces is at least 0
     (0 standard, 1 fourier, >1 fourier with periodicity)"""
+    assert_homogeneous_time_mode(ids)
     for grid_ggd in ids.grid_ggd:
         for space in grid_ggd.space:
             assert space.geometry_type.index >= 0
@@ -220,6 +229,7 @@ def validate_space_geometry_type_identifier(ids):
 def validate_obj_per_dim_geometry_content(ids):
     """Validate that if the geometry_content is filled, its values match
     the reference ggd_geometry_content_identifier."""
+    assert_homogeneous_time_mode(ids)
     for grid_ggd in ids.grid_ggd:
         for space in grid_ggd.space:
             for dim, obj_per_dim in enumerate(space.objects_per_dimension):
@@ -242,6 +252,7 @@ def validate_obj_per_dim_geometry_content(ids):
 def validate_obj_per_dim_geometry_length(ids):
     """Validate that the geometry of the objects have the correct length, according to
     its geometry_content."""
+    assert_homogeneous_time_mode(ids)
     for grid_ggd in ids.grid_ggd:
         for space in grid_ggd.space:
             for dim, obj_per_dim in enumerate(space.objects_per_dimension):
@@ -276,6 +287,7 @@ def validate_obj_per_dim_geometry_length(ids):
 @multi_validator(SUPPORTED_IDS_NAMES)
 def validate_obj_0D_geometry_length(ids):
     """Validate that the geometry of 0D objects is larger than zero."""
+    assert_homogeneous_time_mode(ids)
     for grid_ggd in ids.grid_ggd:
         for space in grid_ggd.space:
             obj_0D = space.objects_per_dimension[0]
@@ -288,6 +300,7 @@ def validate_obj_per_dim_nodes_length(ids):
     """Validate that the nodes of the objects have the correct length.
     0D objects should be empty or contain themselves, edges should contain 2
     nodes, while n-order should contain at least n+1 nodes."""
+    assert_homogeneous_time_mode(ids)
     for grid_ggd in ids.grid_ggd:
         for space in grid_ggd.space:
             for dim, obj_per_dim in enumerate(space.objects_per_dimension):
@@ -306,6 +319,7 @@ def validate_obj_per_dim_nodes_length(ids):
 def validate_obj_per_dim_nodes(ids):
     """Validate that the filled nodes of an object point to
     existing nodes in the grid."""
+    assert_homogeneous_time_mode(ids)
     for grid_ggd in ids.grid_ggd:
         for space in grid_ggd.space:
             len_0D_obj = len(space.objects_per_dimension[0].object)
@@ -319,6 +333,7 @@ def validate_obj_per_dim_nodes(ids):
 @multi_validator(SUPPORTED_IDS_NAMES)
 def validate_obj_per_dim_measure_empty(ids):
     """Validate that the measure value of 0D objects is empty."""
+    assert_homogeneous_time_mode(ids)
     for grid_ggd in ids.grid_ggd:
         for space in grid_ggd.space:
             obj_0D = space.objects_per_dimension[0]
@@ -330,6 +345,7 @@ def validate_obj_per_dim_measure_empty(ids):
 @multi_validator(SUPPORTED_IDS_NAMES)
 def validate_grid_subset_identifier(ids):
     """Validate that grid subset identifier is filled."""
+    assert_homogeneous_time_mode(ids)
     for grid_ggd in ids.grid_ggd:
         for grid_subset in grid_ggd.grid_subset:
             assert_identifier_filled(grid_subset.identifier)
@@ -338,6 +354,7 @@ def validate_grid_subset_identifier(ids):
 @multi_validator(SUPPORTED_IDS_NAMES)
 def validate_grid_subset_length(ids):
     """Validate that the grid has at least 1 grid subset."""
+    assert_homogeneous_time_mode(ids)
     for grid_ggd in ids.grid_ggd:
         assert len(grid_ggd.grid_subset) > 0
 
@@ -345,6 +362,7 @@ def validate_grid_subset_length(ids):
 @multi_validator(SUPPORTED_IDS_NAMES)
 def validate_grid_subset_space_index(ids):
     """Validate that the space in the subset points to an existing space in the grid."""
+    assert_homogeneous_time_mode(ids)
     for grid_ggd in ids.grid_ggd:
         for grid_subset in grid_ggd.grid_subset:
             for element in grid_subset.element:
@@ -357,6 +375,7 @@ def validate_grid_subset_space_index(ids):
 def validate_grid_subset_dimension_index(ids):
     """Validate that the dimension in the grid subset points to
     an existing dimension in the grid."""
+    assert_homogeneous_time_mode(ids)
     for grid_ggd in ids.grid_ggd:
         for grid_subset in grid_ggd.grid_subset:
             for element in grid_subset.element:
@@ -371,6 +390,7 @@ def validate_grid_subset_dimension_index(ids):
 def validate_grid_subset_object_index(ids):
     """Validate that the object index in the grid subset points to an existing
     object in the grid."""
+    assert_homogeneous_time_mode(ids)
     for grid_ggd in ids.grid_ggd:
         for grid_subset in grid_ggd.grid_subset:
             for element in grid_subset.element:
@@ -388,6 +408,7 @@ def validate_grid_subset_object_index(ids):
 def validate_grid_subset_obj_dimension(ids):
     """Validate that the dimensions of the objects of which a grid subset is composed
     are not larger than the dimension of the grid subset itself."""
+    assert_homogeneous_time_mode(ids)
     for grid_ggd in ids.grid_ggd:
         for grid_subset in grid_ggd.grid_subset:
             subset_dim = grid_subset.dimension
@@ -402,6 +423,7 @@ def validate_grid_subset_obj_dimension(ids):
 def validate_ggd_length(ids):
     """Validate that the dimensions of the GGD AoS
     matches the number of time steps."""
+    assert_homogeneous_time_mode(ids)
     ggd_list = get_ggd_aos(ids)
     for ggd_aos in ggd_list:
         assert len(ggd_aos) == len(ids.time)
@@ -411,11 +433,11 @@ def validate_ggd_length(ids):
 def validate_ggd_time_homogeneous(ids):
     """Validate that if the IDS has homogeneous time,
     the time nodes of the individual GGD structures are not filled."""
+    assert_homogeneous_time_mode(ids)
     ggd_list = get_ggd_aos(ids)
-    if ids.ids_properties.homogeneous_time == IDS_TIME_MODE_HOMOGENEOUS:
-        for ggd_aos in ggd_list:
-            for ggd in ggd_aos:
-                assert not ggd.time.has_value
+    for ggd_aos in ggd_list:
+        for ggd in ggd_aos:
+            assert not ggd.time.has_value
 
 
 # GGD array rules
@@ -426,6 +448,7 @@ def validate_ggd_array_match_element(ids):
     definition, which occurs for the ggd subsets named 'nodes', 'edges', 'cells' and
     'volumes' in the reference identifier, the elements can be left empty.
     """
+    assert_homogeneous_time_mode(ids)
     scalar_arrays, vector_arrays = get_filled_ggd_arrays(ids)
     for array in scalar_arrays + vector_arrays:
         for sub_array in array:
@@ -451,6 +474,7 @@ def validate_ggd_array_match_element(ids):
 @multi_validator(SUPPORTED_IDS_NAMES)
 def validate_ggd_array_filled_indices(ids):
     """Validate that all GGD arrays have filled grid_index and grid_subset_index."""
+    assert_homogeneous_time_mode(ids)
     scalar_arrays, vector_arrays = get_filled_ggd_arrays(ids)
     for array in scalar_arrays + vector_arrays:
         for sub_array in array:
@@ -463,6 +487,7 @@ def validate_ggd_array_valid_grid_index(ids):
     """Validate that for the grid_index of a GGD array, the
     identifier index of the corresponding grid_ggd matches.
     """
+    assert_homogeneous_time_mode(ids)
     scalar_arrays, vector_arrays = get_filled_ggd_arrays(ids)
     for array in scalar_arrays + vector_arrays:
         for sub_array in array:
@@ -477,6 +502,7 @@ def validate_ggd_array_valid_grid_subset_index(ids):
     """Validate that the grid_subset_index of a GGD array matches
     with the identifier index of a grid subset.
     """
+    assert_homogeneous_time_mode(ids)
     scalar_arrays, vector_arrays = get_filled_ggd_arrays(ids)
     for array in scalar_arrays + vector_arrays:
         for sub_array in array:
@@ -490,6 +516,7 @@ def validate_ggd_array_valid_grid_subset_index(ids):
 @multi_validator(SUPPORTED_IDS_NAMES)
 def validate_ggd_array_labels_filled(ids):
     """Validate that the labels of ions/neutrals are filled."""
+    assert_homogeneous_time_mode(ids)
     ggd_list = get_ggd_aos(ids)
     label_list = []
     for ggd_aos in ggd_list:

--- a/ids_validator/assets/rulesets/generic/ggd.py
+++ b/ids_validator/assets/rulesets/generic/ggd.py
@@ -1,8 +1,5 @@
 """Rules applying to all IDSs containing GGDs"""
 
-import re
-
-import imaspy
 from imaspy import identifiers
 from imaspy.ids_data_type import IDSDataType
 from imaspy.ids_defs import IDS_TIME_MODE_HOMOGENEOUS
@@ -463,7 +460,8 @@ def validate_ggd_array_match_element(ids):
             )
             if grid_subset is None:
                 raise ValueError(
-                    f"Could not find a matching grid subset with index {grid_subset_index}"
+                    "Could not find a matching grid subset"
+                    f"with index {grid_subset_index}"
                 )
             for quantity in sub_array.iter_nonempty_():
                 if (

--- a/ids_validator/assets/rulesets/generic/ggd.py
+++ b/ids_validator/assets/rulesets/generic/ggd.py
@@ -136,7 +136,7 @@ def recursive_label_search(ggd, label_list):
     """Recursively searches through a GGD structure for quantities which
     have the metadata name 'label', and appends these to the given label_list."""
     for node in ggd:
-        if node.metadata.name == "label" or node.metadata.name == "name":
+        if node.metadata.name == "label":
             label_list.append(node)
         if (
             node.metadata.data_type == IDSDataType.STRUCTURE
@@ -461,6 +461,9 @@ def validate_ggd_array_match_element(ids):
                 raise ValueError(
                     f"Could not find a grid_index with index {grid_subset_index}"
                 )
+            # The identifiers corresponding to nodes (1), edges (2), cells (5),
+            # and volumes (43), contain all nodes by definition. Therefore,
+            # the elements corresponding to these grid subsets may be left empty.
             if grid_subset.identifier.index not in [1, 2, 5, 43]:
                 for quantity in sub_array:
                     if (

--- a/ids_validator/assets/rulesets/generic/ggd.py
+++ b/ids_validator/assets/rulesets/generic/ggd.py
@@ -56,7 +56,10 @@ def assert_index_in_aos_identifier(aos, index):
     """Asserts that a given index appears exactly once in the index identifiers of
     a structure of an AoS."""
     matches = sum(1 for structure in aos if structure.identifier.index == index)
-    assert matches == 1
+    assert matches == 1, (
+        f"{aos} should contain exactly one element with "
+        f"`identifier.index` equal to {index}, but found {matches} elements instead."
+    )
 
 
 def find_structure_by_index(aos, index):

--- a/ids_validator/validate/ids_wrapper.py
+++ b/ids_validator/validate/ids_wrapper.py
@@ -3,7 +3,7 @@ This file describes the overload class for the operators
 """
 
 import operator
-from typing import Any, Callable, Collection, List, Optional, Tuple
+from typing import Any, Callable, Collection, Iterator, List, Optional, Tuple
 
 import numpy as np
 from imaspy.ids_primitive import IDSPrimitive
@@ -115,7 +115,7 @@ class IDSWrapper:
     def __repr__(self) -> str:
         return f"IDSWrapper({self._obj!r})"
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[int]:
         return iter(self._obj)
 
     def __str__(self) -> str:

--- a/ids_validator/validate/ids_wrapper.py
+++ b/ids_validator/validate/ids_wrapper.py
@@ -118,6 +118,9 @@ class IDSWrapper:
     def __str__(self) -> str:
         return str(self._obj)
 
+    def __int__(self) -> int:
+        return int(self._obj)
+
     # comparison operators
     __eq__ = _binary_wrapper(operator.eq, "eq")
     __ne__ = _binary_wrapper(operator.ne, "ne")

--- a/ids_validator/validate/ids_wrapper.py
+++ b/ids_validator/validate/ids_wrapper.py
@@ -115,6 +115,9 @@ class IDSWrapper:
     def __repr__(self) -> str:
         return f"IDSWrapper({self._obj!r})"
 
+    def __iter__(self):
+        return iter(self._obj)
+
     def __str__(self) -> str:
         return str(self._obj)
 

--- a/ids_validator/validate/ids_wrapper.py
+++ b/ids_validator/validate/ids_wrapper.py
@@ -120,8 +120,9 @@ class IDSWrapper:
     def __repr__(self) -> str:
         return f"IDSWrapper({self._obj!r})"
 
-    def __iter__(self) -> Iterator[Any]:
-        return iter(self._obj)
+    def __iter__(self) -> Iterator["IDSWrapper"]:
+        for item in self._obj:
+            yield IDSWrapper(item, ids_nodes=self._ids_nodes)
 
     def __str__(self) -> str:
         return str(self._obj)

--- a/ids_validator/validate/ids_wrapper.py
+++ b/ids_validator/validate/ids_wrapper.py
@@ -115,7 +115,7 @@ class IDSWrapper:
     def __repr__(self) -> str:
         return f"IDSWrapper({self._obj!r})"
 
-    def __iter__(self) -> Iterator[int]:
+    def __iter__(self) -> Iterator[Any]:
         return iter(self._obj)
 
     def __str__(self) -> str:

--- a/imas_validator/assets/rulesets/generic/ggd.py
+++ b/imas_validator/assets/rulesets/generic/ggd.py
@@ -200,7 +200,7 @@ def validate_space_coordinates_type_identifier(ids):
         for space in grid_ggd.space:
             for coord_type in space.coordinates_type:
                 assert is_index_in_identifier_ref(
-                    coord_type, identifiers.coordinate_identifier
+                    coord_type.index, identifiers.coordinate_identifier
                 ), "space.coordinates_type not in coordinate identifier reference list"
 
 

--- a/imas_validator/assets/rulesets/generic/ggd.py
+++ b/imas_validator/assets/rulesets/generic/ggd.py
@@ -143,6 +143,9 @@ def get_objects_from_path(ids, path, descend_final):
     for i, part in enumerate(parts):
         next_level = []
         for obj in current:
+            # If IDS path cannot be found, skip it
+            if not hasattr(obj, part):
+                continue
             attr = obj[part]
             if i == len(parts) - 1 and not descend_final:
                 next_level.append(attr)

--- a/imas_validator/assets/rulesets/generic/ggd.py
+++ b/imas_validator/assets/rulesets/generic/ggd.py
@@ -2,7 +2,7 @@
 
 from imas import identifiers
 from imas.ids_data_type import IDSDataType
-from imas.ids_defs import IDS_TIME_MODE_HOMOGENEOUS
+from imas.ids_defs import IDS_TIME_MODE_HETEROGENEOUS, IDS_TIME_MODE_HOMOGENEOUS
 
 SUPPORTED_IDS_NAMES = [
     "edge_profiles",
@@ -31,10 +31,11 @@ SUPPORTED_IDS_NAMES = [
 
 # Helper functions
 def has_homogeneous_time(ids):
-    if ids.ids_properties.homogeneous_time == IDS_TIME_MODE_HOMOGENEOUS:
-        return True
-    else:
-        return False
+    return ids.ids_properties.homogeneous_time == IDS_TIME_MODE_HOMOGENEOUS
+
+
+def has_heterogeneous_time(ids):
+    return ids.ids_properties.homogeneous_time == IDS_TIME_MODE_HETEROGENEOUS
 
 
 def multi_validator(ids_names):
@@ -138,13 +139,21 @@ def get_filled_ggd_arrays(ids):
     return scalar_arrays, vector_arrays
 
 
+def get_non_referenced_grids(ids):
+    """Get a list of each grid GGD object that does not have a reference path."""
+    non_referenced_grids = []
+    for grid_ggd in ids.grid_ggd:
+        # TODO: Referenced grids are currently not checked
+        if not grid_ggd.path:
+            non_referenced_grids.append(grid_ggd)
+    return non_referenced_grids
+
+
 # Grid rules
 @multi_validator(SUPPORTED_IDS_NAMES)
 def validate_grid_ggd_identifier(ids):
     """Validate that the identifiers of all grid_ggds are filled."""
-    if not has_homogeneous_time(ids):
-        return
-    for grid_ggd in ids.grid_ggd:
+    for grid_ggd in get_non_referenced_grids(ids):
         assert_identifier_filled(grid_ggd.identifier)
 
 
@@ -152,33 +161,33 @@ def validate_grid_ggd_identifier(ids):
 def validate_grid_ggd_length(ids):
     """Validate that the number of structures in the grid_ggd AoS match
     the number of time steps."""
-    if not has_homogeneous_time(ids):
-        return
     assert len(ids.grid_ggd) == len(ids.time), (
         "Number of grid_ggd structures must match the number of time steps"
     )
 
 
 @multi_validator(SUPPORTED_IDS_NAMES)
-def validate_grid_ggd_time_homogeneous(ids):
+def validate_grid_ggd_time(ids):
     """Validate that if the IDS has homogeneous time,
     the time nodes in the individual grid_ggd structures are not filled."""
-    if not has_homogeneous_time(ids):
-        return
-    for grid_ggd in ids.grid_ggd:
-        assert not grid_ggd.time.has_value, (
-            "Time nodes in individual grid_ggd structures should not be filled "
-            "for homogeneous time"
-        )
+    for grid_ggd in get_non_referenced_grids(ids):
+        if has_homogeneous_time(ids):
+            assert not grid_ggd.time.has_value, (
+                "Time nodes in individual grid_ggd structures should not be filled "
+                "for homogeneous time"
+            )
+        elif has_heterogeneous_time(ids):
+            assert grid_ggd.time.has_value, (
+                "Time nodes in individual grid_ggd structures should be filled "
+                "for heterogeneous time"
+            )
 
 
 # Space rules
 @multi_validator(SUPPORTED_IDS_NAMES)
 def validate_space_identifier(ids):
     """Validate that the identifiers of all grid_ggd spaces are filled"""
-    if not has_homogeneous_time(ids):
-        return
-    for grid_ggd in ids.grid_ggd:
+    for grid_ggd in get_non_referenced_grids(ids):
         for space in grid_ggd.space:
             assert_identifier_filled(space.identifier)
 
@@ -187,9 +196,7 @@ def validate_space_identifier(ids):
 def validate_space_coordinates_type_identifier(ids):
     """Validate that the space.coordinate_types match with ones that
     are in the coordinate identifier reference list."""
-    if not has_homogeneous_time(ids):
-        return
-    for grid_ggd in ids.grid_ggd:
+    for grid_ggd in get_non_referenced_grids(ids):
         for space in grid_ggd.space:
             for coord_type in space.coordinates_type:
                 assert is_index_in_identifier_ref(
@@ -201,9 +208,7 @@ def validate_space_coordinates_type_identifier(ids):
 def validate_space_geometry_type_identifier(ids):
     """Validate that the geometry_type of all spaces is at least 0
     (0 standard, 1 fourier, >1 fourier with periodicity)"""
-    if not has_homogeneous_time(ids):
-        return
-    for grid_ggd in ids.grid_ggd:
+    for grid_ggd in get_non_referenced_grids(ids):
         for space in grid_ggd.space:
             assert space.geometry_type.index >= 0, (
                 "space.geometry_type.index must be >= 0"
@@ -215,9 +220,7 @@ def validate_space_geometry_type_identifier(ids):
 def validate_obj_per_dim_geometry_content(ids):
     """Validate that if the geometry_content is filled, its values match
     the reference ggd_geometry_content_identifier."""
-    if not has_homogeneous_time(ids):
-        return
-    for grid_ggd in ids.grid_ggd:
+    for grid_ggd in get_non_referenced_grids(ids):
         for space in grid_ggd.space:
             for dim, obj_per_dim in enumerate(space.objects_per_dimension):
                 geometry_content = obj_per_dim.geometry_content.index
@@ -250,9 +253,7 @@ def validate_obj_per_dim_geometry_content(ids):
 def validate_obj_per_dim_geometry_length(ids):
     """Validate that the geometry of the objects have the correct length, according to
     its geometry_content."""
-    if not has_homogeneous_time(ids):
-        return
-    for grid_ggd in ids.grid_ggd:
+    for grid_ggd in get_non_referenced_grids(ids):
         for space in grid_ggd.space:
             for dim, obj_per_dim in enumerate(space.objects_per_dimension):
                 geometry_content = obj_per_dim.geometry_content
@@ -302,9 +303,7 @@ def validate_obj_per_dim_geometry_length(ids):
 @multi_validator(SUPPORTED_IDS_NAMES)
 def validate_obj_0D_geometry_length(ids):
     """Validate that the geometry of 0D objects is larger than zero."""
-    if not has_homogeneous_time(ids):
-        return
-    for grid_ggd in ids.grid_ggd:
+    for grid_ggd in get_non_referenced_grids(ids):
         for space in grid_ggd.space:
             obj_0D = space.objects_per_dimension[0]
             for obj in obj_0D.object:
@@ -318,9 +317,7 @@ def validate_obj_per_dim_nodes_length(ids):
     """Validate that the nodes of the objects have the correct length.
     0D objects should be empty or contain themselves, edges should contain 2
     nodes, while n-order should contain at least n+1 nodes."""
-    if not has_homogeneous_time(ids):
-        return
-    for grid_ggd in ids.grid_ggd:
+    for grid_ggd in get_non_referenced_grids(ids):
         for space in grid_ggd.space:
             for dim, obj_per_dim in enumerate(space.objects_per_dimension):
                 for i, obj in enumerate(obj_per_dim.object):
@@ -343,9 +340,7 @@ def validate_obj_per_dim_nodes_length(ids):
 def validate_obj_per_dim_nodes(ids):
     """Validate that the filled nodes of an object point to
     existing nodes in the grid."""
-    if not has_homogeneous_time(ids):
-        return
-    for grid_ggd in ids.grid_ggd:
+    for grid_ggd in get_non_referenced_grids(ids):
         for space in grid_ggd.space:
             len_0D_obj = len(space.objects_per_dimension[0].object)
             for obj_per_dim in space.objects_per_dimension:
@@ -360,9 +355,7 @@ def validate_obj_per_dim_nodes(ids):
 @multi_validator(SUPPORTED_IDS_NAMES)
 def validate_obj_per_dim_measure_empty(ids):
     """Validate that the measure value of 0D objects is empty."""
-    if not has_homogeneous_time(ids):
-        return
-    for grid_ggd in ids.grid_ggd:
+    for grid_ggd in get_non_referenced_grids(ids):
         for space in grid_ggd.space:
             obj_0D = space.objects_per_dimension[0]
             for obj in obj_0D.object:
@@ -373,9 +366,7 @@ def validate_obj_per_dim_measure_empty(ids):
 @multi_validator(SUPPORTED_IDS_NAMES)
 def validate_grid_subset_identifier(ids):
     """Validate that grid subset identifier is filled."""
-    if not has_homogeneous_time(ids):
-        return
-    for grid_ggd in ids.grid_ggd:
+    for grid_ggd in get_non_referenced_grids(ids):
         for grid_subset in grid_ggd.grid_subset:
             assert_identifier_filled(grid_subset.identifier)
 
@@ -383,9 +374,7 @@ def validate_grid_subset_identifier(ids):
 @multi_validator(SUPPORTED_IDS_NAMES)
 def validate_grid_subset_length(ids):
     """Validate that the grid has at least 1 grid subset."""
-    if not has_homogeneous_time(ids):
-        return
-    for grid_ggd in ids.grid_ggd:
+    for grid_ggd in get_non_referenced_grids(ids):
         assert len(grid_ggd.grid_subset) > 0, (
             "GGD grid must have at least 1 grid_subset"
         )
@@ -394,9 +383,7 @@ def validate_grid_subset_length(ids):
 @multi_validator(SUPPORTED_IDS_NAMES)
 def validate_grid_subset_space_index(ids):
     """Validate that the space in the subset points to an existing space in the grid."""
-    if not has_homogeneous_time(ids):
-        return
-    for grid_ggd in ids.grid_ggd:
+    for grid_ggd in get_non_referenced_grids(ids):
         for grid_subset in grid_ggd.grid_subset:
             for element in grid_subset.element:
                 for object in element.object:
@@ -408,9 +395,7 @@ def validate_grid_subset_space_index(ids):
 def validate_grid_subset_dimension_index(ids):
     """Validate that the dimension in the grid subset points to
     an existing dimension in the grid."""
-    if not has_homogeneous_time(ids):
-        return
-    for grid_ggd in ids.grid_ggd:
+    for grid_ggd in get_non_referenced_grids(ids):
         for grid_subset in grid_ggd.grid_subset:
             for element in grid_subset.element:
                 for object in element.object:
@@ -429,9 +414,7 @@ def validate_grid_subset_dimension_index(ids):
 def validate_grid_subset_object_index(ids):
     """Validate that the object index in the grid subset points to an existing
     object in the grid."""
-    if not has_homogeneous_time(ids):
-        return
-    for grid_ggd in ids.grid_ggd:
+    for grid_ggd in get_non_referenced_grids(ids):
         for grid_subset in grid_ggd.grid_subset:
             for element in grid_subset.element:
                 for object in element.object:
@@ -450,9 +433,7 @@ def validate_grid_subset_object_index(ids):
 def validate_grid_subset_obj_dimension(ids):
     """Validate that the dimensions of the objects of which a grid subset is composed
     are not larger than the dimension of the grid subset itself."""
-    if not has_homogeneous_time(ids):
-        return
-    for grid_ggd in ids.grid_ggd:
+    for grid_ggd in get_non_referenced_grids(ids):
         for grid_subset in grid_ggd.grid_subset:
             subset_dim = grid_subset.dimension
             for element in grid_subset.element:
@@ -468,8 +449,6 @@ def validate_grid_subset_obj_dimension(ids):
 def validate_ggd_length(ids):
     """Validate that the dimensions of the GGD AoS
     matches the number of time steps."""
-    if not has_homogeneous_time(ids):
-        return
     ggd_list = get_ggd_aos(ids)
     for ggd_aos in ggd_list:
         assert len(ggd_aos) == len(ids.time), (
@@ -481,8 +460,6 @@ def validate_ggd_length(ids):
 def validate_ggd_time_homogeneous(ids):
     """Validate that if the IDS has homogeneous time,
     the time nodes of the individual GGD structures are not filled."""
-    if not has_homogeneous_time(ids):
-        return
     ggd_list = get_ggd_aos(ids)
     for ggd_aos in ggd_list:
         for ggd in ggd_aos:
@@ -499,8 +476,6 @@ def validate_ggd_array_match_element(ids):
     definition, which occurs for the ggd subsets named 'nodes', 'edges', 'cells' and
     'volumes' in the reference identifier, the elements can be left empty.
     """
-    if not has_homogeneous_time(ids):
-        return
     scalar_arrays, vector_arrays = get_filled_ggd_arrays(ids)
     for array in scalar_arrays + vector_arrays:
         for sub_array in array:
@@ -530,8 +505,6 @@ def validate_ggd_array_valid_grid_index(ids):
     """Validate that for the grid_index of a GGD array, the
     identifier index of the corresponding grid_ggd matches.
     """
-    if not has_homogeneous_time(ids):
-        return
     scalar_arrays, vector_arrays = get_filled_ggd_arrays(ids)
     for array in scalar_arrays + vector_arrays:
         for sub_array in array:
@@ -553,8 +526,6 @@ def validate_ggd_array_valid_grid_subset_index(ids):
     """Validate that the grid_subset_index of a GGD array matches
     with the identifier index of a grid subset.
     """
-    if not has_homogeneous_time(ids):
-        return
     scalar_arrays, vector_arrays = get_filled_ggd_arrays(ids)
     for array in scalar_arrays + vector_arrays:
         for sub_array in array:
@@ -574,7 +545,5 @@ def validate_ggd_array_valid_grid_subset_index(ids):
 @multi_validator(SUPPORTED_IDS_NAMES)
 def validate_ggd_array_labels_filled(ids):
     """Validate that the labels of ions/neutrals are filled."""
-    if not has_homogeneous_time(ids):
-        return
     for label in Select(ids, "/label$"):
         assert label.has_value, "labels of ions/neutrals must be filled"

--- a/imas_validator/assets/rulesets/generic/ggd.py
+++ b/imas_validator/assets/rulesets/generic/ggd.py
@@ -4,7 +4,7 @@ from imas import identifiers
 from imas.ids_data_type import IDSDataType
 from imas.ids_defs import IDS_TIME_MODE_HOMOGENEOUS
 
-SUPPORTED_IDS_NAMES = (
+SUPPORTED_IDS_NAMES = [
     "edge_profiles",
     "edge_sources",
     "edge_transport",
@@ -12,7 +12,10 @@ SUPPORTED_IDS_NAMES = (
     "radiation",
     "runaway_electrons",
     "wall",
-)
+    "plasma_profiles",
+    "plasma_sources",
+    "plasma_transport",
+]
 
 # TODO: Some IDSs do not have the grid structure in a separate `grid_ggd` object, as
 # described by the GGD guidelines. They are currently not covered by the validations.

--- a/imas_validator/assets/rulesets/generic/ggd.py
+++ b/imas_validator/assets/rulesets/generic/ggd.py
@@ -11,7 +11,6 @@ SUPPORTED_IDS_NAMES = [
     "mhd",
     "radiation",
     "runaway_electrons",
-    "wall",
     "plasma_profiles",
     "plasma_sources",
     "plasma_transport",
@@ -21,6 +20,7 @@ SUPPORTED_IDS_NAMES = [
 # described by the GGD guidelines. They are currently not covered by the validations.
 # If the DD for these IDSs stays like this, they will need to be handled separately.
 # GGD grid locations for each IDS:
+# wall (description_ggd/grid_ggd)
 # equilibrium (grids_ggd/grid)
 # distribution_sources (source/ggd/grid)
 # distributions (distribution/ggd/grid)

--- a/imas_validator/assets/rulesets/generic/ggd.py
+++ b/imas_validator/assets/rulesets/generic/ggd.py
@@ -1,8 +1,8 @@
 """Rules applying to all IDSs containing GGDs"""
 
-from imaspy import identifiers
-from imaspy.ids_data_type import IDSDataType
-from imaspy.ids_defs import IDS_TIME_MODE_HOMOGENEOUS
+from imas import identifiers
+from imas.ids_data_type import IDSDataType
+from imas.ids_defs import IDS_TIME_MODE_HOMOGENEOUS
 
 SUPPORTED_IDS_NAMES = (
     "edge_profiles",
@@ -125,7 +125,6 @@ def get_filled_ggd_arrays(ids):
     vector_arrays = []
     for ggd_aos in ggd_list:
         for ggd in ggd_aos:
-
             recursive_ggd_path_search(
                 ggd,
                 scalar_arrays,

--- a/imas_validator/assets/rulesets/generic/ggd.py
+++ b/imas_validator/assets/rulesets/generic/ggd.py
@@ -7,27 +7,27 @@ from imas.ids_defs import IDS_TIME_MODE_HETEROGENEOUS, IDS_TIME_MODE_HOMOGENEOUS
 # As IDSs store their GGD grid and GGD AoS in different locations, they are explicitly
 # mapped here. If you want to enable GGD validation for a new IDS, amend it to this
 # mapping. This takes the following form:
-# "<IDS name>": ("<GGD grid IDS path>", "<GGD IDS path>")
+# "<IDS name>": ("<GGD grid IDS path>", ["<GGD IDS path1>", "<GGD IDS path2>", ...])
 GGD_PATHS_PER_IDS = {
-    "edge_profiles": ("grid_ggd", "ggd"),
-    "edge_sources": ("grid_ggd", "source/ggd"),
-    "edge_transport": ("grid_ggd", "model/ggd"),
-    "mhd": ("grid_ggd", "ggd"),
-    "radiation": ("grid_ggd", "process/ggd"),
-    "runaway_electrons": ("grid_ggd", "ggd_fluid"),
-    "plasma_profiles": ("grid_ggd", "ggd"),
-    "plasma_sources": ("grid_ggd", "source/ggd"),
-    "plasma_transport": ("grid_ggd", "model/ggd"),
-    "wall": ("description_ggd", "description_ggd/ggd"),
-    "equilibrium": ("grids_ggd/grid", "time_slice/ggd"),
-    "distribution_sources": ("source/ggd/grid", "source/ggd"),
-    "distributions": ("distribution/ggd/grid", "distribution/ggd"),
-    "tf": ("field_map/grid", "field_map"),
+    "edge_profiles": ("grid_ggd", ["ggd", "ggd_fast"]),
+    "edge_sources": ("grid_ggd", ["source/ggd", "source/ggd_fast"]),
+    "edge_transport": ("grid_ggd", ["model/ggd", "model/ggd_fast"]),
+    "mhd": ("grid_ggd", ["ggd"]),
+    "radiation": ("grid_ggd", ["process/ggd"]),
+    "runaway_electrons": ("grid_ggd", ["ggd_fluid"]),
+    "plasma_profiles": ("grid_ggd", ["ggd", "ggd_fast"]),
+    "plasma_sources": ("grid_ggd", ["source/ggd", "source/ggd_fast"]),
+    "plasma_transport": ("grid_ggd", ["model/ggd", "model/ggd_fast"]),
+    "wall": ("description_ggd/grid_ggd", ["description_ggd/ggd"]),
+    "equilibrium": ("grids_ggd/grid", ["time_slice/ggd"]),
+    "distribution_sources": ("source/ggd/grid", ["source/ggd"]),
+    "distributions": ("distribution/ggd/grid", ["distribution/ggd"]),
+    "tf": ("field_map/grid", ["field_map"]),
     "transport_solver_numerics": (
         "boundary_conditions_ggd/grid",
-        "boundary_conditions_ggd",
+        ["boundary_conditions_ggd"],
     ),
-    "waves": ("coherent_wave/full_wave/grid", "coherent_wave/full_wave"),
+    "waves": ("coherent_wave/full_wave/grid", ["coherent_wave/full_wave"]),
 }
 
 
@@ -158,12 +158,18 @@ def get_ggds(ids, descend_final=True):
     _, ggd_map = GGD_PATHS_PER_IDS[str(ids.metadata.name)]
     if not ggd_map:
         return []
-    return get_objects_from_path(ids, ggd_map, descend_final)
+    ggds = []
+    for ggd_path in ggd_map:
+        current_ggds = get_objects_from_path(ids, ggd_path, descend_final)
+        ggds.extend(current_ggds)
+    return ggds
 
 
 def get_grid_ggds(ids, descend_final=True):
     """Get a list of all grid GGD nodes in the IDS"""
     grid_ggd_map, _ = GGD_PATHS_PER_IDS[str(ids.metadata.name)]
+    if not grid_ggd_map:
+        return []
     return get_objects_from_path(ids, grid_ggd_map, descend_final)
 
 

--- a/imas_validator/assets/rulesets/generic/ggd.py
+++ b/imas_validator/assets/rulesets/generic/ggd.py
@@ -230,7 +230,7 @@ def validate_space_coordinates_type_identifier(ids):
                         coord_type, identifiers.coordinate_identifier
                     )
             else:
-                for coord_type_identifier in space.coordinates_type:
+                for coord_type_identifier in coordinates_type:
                     assert_valid_identifier(
                         coord_type_identifier, identifiers.coordinate_identifier
                     )

--- a/imas_validator/assets/rulesets/generic/ggd.py
+++ b/imas_validator/assets/rulesets/generic/ggd.py
@@ -61,7 +61,7 @@ def assert_index_in_aos_identifier(aos, index):
     a structure of an AoS."""
     matches = sum(1 for structure in aos if structure.identifier.index == index)
     assert matches == 1, (
-        f"{aos} should contain exactly one element with "
+        f"{aos.metadata.path} should contain exactly one element with "
         f"`identifier.index` equal to {index}, but found {matches} elements instead."
     )
 
@@ -72,7 +72,7 @@ def find_structure_by_index(aos, index):
     for structure in aos:
         if structure.identifier.index == index:
             return structure
-    assert False, f"{aos} does not have an identifier index of {index}"
+    assert False, f"{aos.metadata.path} does not have an identifier index of {index}"
 
 
 def is_index_in_identifier_ref(index, identifier_ref):
@@ -155,6 +155,9 @@ def validate_grid_ggd_identifier(ids):
     """Validate that the identifiers of all grid_ggds are filled."""
     for grid_ggd in get_non_referenced_grids(ids):
         assert_identifier_filled(grid_ggd.identifier)
+        assert grid_ggd.identifier.index > 0, (
+            "The identifier index of a grid GGD must be larger than 0"
+        )
 
 
 @multi_validator(SUPPORTED_IDS_NAMES)

--- a/imas_validator/assets/rulesets/generic/ggd.py
+++ b/imas_validator/assets/rulesets/generic/ggd.py
@@ -71,6 +71,7 @@ def find_structure_by_index(aos, index):
     for structure in aos:
         if structure.identifier.index == index:
             return structure
+    assert False, f"{aos} does not have an indentifier with the index {index}"
 
 
 def is_index_in_identifier_ref(index, identifier_ref):
@@ -212,7 +213,7 @@ def validate_obj_per_dim_geometry_content(ids):
     for grid_ggd in ids.grid_ggd:
         for space in grid_ggd.space:
             for dim, obj_per_dim in enumerate(space.objects_per_dimension):
-                geometry_content = obj_per_dim.geometry_content
+                geometry_content = obj_per_dim.geometry_content.index
                 if geometry_content.has_value and geometry_content != 0:
                     # When the geometry content is filled, they should adhere to
                     # the indices provided in the ggd_geometry_content_identifier.
@@ -220,11 +221,11 @@ def validate_obj_per_dim_geometry_content(ids):
                     # What each of these geometry content indices mean, is described in
                     # more detail in validate_obj_per_dim_geometry_length()
                     if dim == 0:
-                        assert geometry_content in {1, 11}
+                        assert int(geometry_content) in {1, 11}
                     elif dim == 1:
-                        assert geometry_content == 21
+                        assert int(geometry_content) == 21
                     elif dim == 2:
-                        assert geometry_content in {31, 32}
+                        assert int(geometry_content) in {31, 32}
                     else:
                         assert False, (
                             "geometry_content undefined for "
@@ -376,6 +377,8 @@ def validate_grid_subset_dimension_index(ids):
                     dim = object.dimension
                     space_idx = object.space
                     space = find_structure_by_index(grid_ggd.space, space_idx)
+                    if space is None:
+                        continue
                     assert len(space.objects_per_dimension) >= dim
 
 
@@ -393,6 +396,8 @@ def validate_grid_subset_object_index(ids):
                     space_idx = object.space
                     obj_idx = object.index
                     space = find_structure_by_index(grid_ggd.space, space_idx)
+                    if space is None:
+                        continue
                     assert (
                         len(space.objects_per_dimension[dim - 1].object) >= obj_idx > 0
                     )
@@ -454,17 +459,12 @@ def validate_ggd_array_match_element(ids):
             grid_subset_index = sub_array.grid_subset_index
             matching_grid_ggd = find_structure_by_index(ids.grid_ggd, grid_index)
             if matching_grid_ggd is None:
-                raise ValueError(
-                    f"Could not find a matching grid with index {grid_index}"
-                )
+                continue
             grid_subset = find_structure_by_index(
                 matching_grid_ggd.grid_subset, grid_subset_index
             )
             if grid_subset is None:
-                raise ValueError(
-                    "Could not find a matching grid subset"
-                    f"with index {grid_subset_index}"
-                )
+                continue
             for quantity in sub_array.iter_nonempty_():
                 if (
                     quantity.metadata.name != "grid_index"
@@ -486,6 +486,8 @@ def validate_ggd_array_valid_grid_index(ids):
             assert sub_array.grid_index.has_value
             grid_index = sub_array.grid_index
             matching_grid_ggd = find_structure_by_index(ids.grid_ggd, grid_index)
+            if matching_grid_ggd is None:
+                continue
             grid_ggd_index = matching_grid_ggd.identifier.index
             assert grid_index == grid_ggd_index
 
@@ -504,6 +506,8 @@ def validate_ggd_array_valid_grid_subset_index(ids):
             grid_index = sub_array.grid_index
             grid_subset_index = sub_array.grid_subset_index
             matching_grid_ggd = find_structure_by_index(ids.grid_ggd, grid_index)
+            if matching_grid_ggd is None:
+                continue
             assert_index_in_aos_identifier(
                 matching_grid_ggd.grid_subset, grid_subset_index
             )

--- a/imas_validator/assets/rulesets/generic/ggd.py
+++ b/imas_validator/assets/rulesets/generic/ggd.py
@@ -354,12 +354,14 @@ def validate_obj_per_dim_nodes(ids):
 
 @multi_validator(SUPPORTED_IDS_NAMES)
 def validate_obj_per_dim_measure_empty(ids):
-    """Validate that the measure value of 0D objects is empty."""
+    """Validate that the measure value of 0D objects is empty or zero."""
     for grid_ggd in get_non_referenced_grids(ids):
         for space in grid_ggd.space:
             obj_0D = space.objects_per_dimension[0]
             for obj in obj_0D.object:
-                assert not obj.measure.has_value, "measure of 0D objects must be empty"
+                assert not obj.measure.has_value or obj.measure.value == 0, (
+                    "measure of 0D objects must be empty or zero"
+                )
 
 
 # Grid subset rules


### PR DESCRIPTION
This introduces a generic rule set, which is responsible for checking the validity of GGD grids and their GGD arrays. These were originally discussed in [this JIRA ticket](https://jira.iter.org/browse/IMAS-5559), though a few minor changes have been made since then. The rules have been tested on the following three datasets:

- SOLPS case: `imas:hdf5?path=/work/imas/shared/imasdb/ITER_SCENARIOS/3/123364/1`
  - `edge_profiles`
- JOREK case: `imas:hdf5?user=public;pulse=113112;run=1;database=ITER_DISRUPTIONS;version=4`
  - `plasma_profiles`, occurrence=1, only first time step was tested
- JINTRAC case: `imas:hdf5?path=/work/imas/shared/TEST/simulations/test/8743dad6d7f211ef8fd59440c9e7706c/imasdb/iter/3/53298/2`
  - `edge_profiles`, only first time step was tested

The datasets above do raise validation errors, but in my opinion these are issues with how the GGD data is filled and not with the GGD ruleset, but let's discuss! The found issues are described below:

### SOLPS
- `grid_ggd[0]/identifier/description` is empty
- `grid_ggd[0]/space[0]/identifier/description` is empty
- `grid_ggd[0].space[0].objects_per_dimension[2].object[5641:6026]` do not have any nodes.
- The following GGD arrays contain an AoS for each grid subset but ggd arrays itself are empty
  - j_parallel
  - electrons/velocity
  - j_total
  - j_anomalous
  - j_inertial
  - j_ion_neutral_friction
  - j_parallel_viscosity
  - j_perpendicular_viscosity
  - j_heat_viscosity
  - j_diamagnetic
  

### JOREK
- `grid_ggd[0]/space[0]/identifier` is empty 
- objects refer to space with index 1 which does not exist (probably related to issue above)
- `grid_ggd[0]/space[0]/objects_per_dimension[1]/object[0].node` contains the 0th node (node indices must start from 1)
- `grid_ggd[0]/identifier` has index of 0, while GGD arrays refer to a grid with index 1 (which does not exist). 

### JINTRAC
- Some dimensions of objects in grid subset’s elements are larger than the subset dimension
  - e.g. `ids.grid_ggd[0].grid_subset[4].dimension == 2` , while `ids.grid_ggd[0].grid_subset[4].element[1254].object[0].dimension == 3`
  - How can a grid subset with dimension 2 (a line), contain elements which have a dimension of 3 (a face)?

> [!NOTE]  
> Referenced grids (through the grid_ggd.path attribute) are currently not supported and will raise validation errors, as the grid is not able to be found in the IDS.