### PR TITLE
Fix GGD ruleset causing CI failure

### DIFF
--- a/imas_validator/assets/rulesets/generic/ggd.py
+++ b/imas_validator/assets/rulesets/generic/ggd.py
@@ -77,14 +77,21 @@ def assert_index_in_aos_identifier(aos, index):
     )
 
 
-def find_structure_by_index(list_of_aos, index):
-    """Return the first object in a list of AoSs whose identifier.index matches the
-    given index, or None if no match is found."""
-    for aos in list_of_aos:
-        for structure in aos:
-            if structure.identifier.index == index:
-                return structure
-    assert False, f"{list_of_aos} does not have an AoS with identifier index of {index}"
+def find_structure_by_index(list_of_objs, index):
+    """Return the first object in a list of AoSs or list of structures whose
+    identifier.index matches the given index, or None if no match is found."""
+    for obj in list_of_objs:
+        if obj.metadata.data_type == IDSDataType.STRUCT_ARRAY:
+            for structure in obj:
+                if structure.identifier.index == index:
+                    return structure
+        elif obj.metadata.data_type == IDSDataType.STRUCTURE:
+            if obj.identifier.index == index:
+                return obj
+
+    assert False, (
+        f"{list_of_objs} does not have a structure with an identifier index of {index}"
+    )
 
 
 def recursive_ggd_path_search(quantity, scalar_list, vector_list):
@@ -173,7 +180,20 @@ def get_grid_ggds(ids, descend_final=True):
     grid_ggd_map, _ = GGD_PATHS_PER_IDS[str(ids.metadata.name)]
     if not grid_ggd_map:
         return []
-    return get_objects_from_path(ids, grid_ggd_map, descend_final)
+
+    objs = get_objects_from_path(ids, grid_ggd_map, descend_final=False)
+
+    if not descend_final:
+        return objs
+
+    list_of_grid_ggds = []
+    for obj in objs:
+        if obj.metadata.data_type == IDSDataType.STRUCT_ARRAY:
+            list_of_grid_ggds.extend(obj)
+        elif obj.metadata.data_type == IDSDataType.STRUCTURE:
+            list_of_grid_ggds.append(obj)
+
+    return list_of_grid_ggds
 
 
 def get_defined_grids(ids):

--- a/imas_validator/assets/rulesets/generic/ggd.py
+++ b/imas_validator/assets/rulesets/generic/ggd.py
@@ -53,9 +53,9 @@ def multi_validator(ggd_mapping):
 
 def assert_index_in_identifier_reference(index, identifier_ref):
     """Asserts that an index exists in the identifier reference."""
-    assert any(index == member.value for member in identifier_ref), (
-        f"Identifier index {index} does not appear in {identifier_ref}"
-    )
+    assert any(
+        index == member.value for member in identifier_ref
+    ), f"Identifier index {index} does not appear in {identifier_ref}"
 
 
 def assert_valid_identifier(identifier, identifier_ref=None):
@@ -89,9 +89,9 @@ def find_structure_by_index(list_of_objs, index):
             if obj.identifier.index == index:
                 return obj
 
-    assert False, (
-        f"{list_of_objs} does not have a structure with an identifier index of {index}"
-    )
+    assert (
+        False
+    ), f"{list_of_objs} does not have a structure with an identifier index of {index}"
 
 
 def recursive_ggd_path_search(quantity, scalar_list, vector_list):
@@ -222,9 +222,9 @@ def validate_grid_ggd_size(ids):
         grid_ggds = get_grid_ggds(ids, descend_final=False)
         for grid_ggd in grid_ggds:
             if grid_ggd.metadata.structure_reference == "generic_grid_aos3_root":
-                assert len(grid_ggd) == len(ids.time), (
-                    "Number of grid_ggd structures must match the number of time steps"
-                )
+                assert len(grid_ggd) == len(
+                    ids.time
+                ), "Number of grid_ggd structures must match the number of time steps"
 
 
 @multi_validator(GGD_PATHS_PER_IDS)
@@ -277,9 +277,9 @@ def validate_space_geometry_type_identifier(ids):
     (0 standard, 1 fourier, >1 fourier with periodicity)"""
     for grid_ggd in get_defined_grids(ids):
         for space in grid_ggd.space:
-            assert space.geometry_type.index >= 0, (
-                "space.geometry_type.index must be >= 0"
-            )
+            assert (
+                space.geometry_type.index >= 0
+            ), "space.geometry_type.index must be >= 0"
 
 
 # Objects_per_dimension rules
@@ -298,17 +298,19 @@ def validate_obj_per_dim_geometry_content(ids):
                     # What each of these geometry content indices mean, is described in
                     # more detail in validate_obj_per_dim_geometry_length()
                     if dim == 0:
-                        assert int(geometry_content) in {1, 11}, (
-                            "0D geometry_content must be either 1, or 11"
-                        )
+                        assert int(geometry_content) in {
+                            1,
+                            11,
+                        }, "0D geometry_content must be either 1, or 11"
                     elif dim == 1:
-                        assert int(geometry_content) == 21, (
-                            "1D geometry_content must be 21"
-                        )
+                        assert (
+                            int(geometry_content) == 21
+                        ), "1D geometry_content must be 21"
                     elif dim == 2:
-                        assert int(geometry_content) in {31, 32}, (
-                            "2D geometry_content must be either 31, or 32"
-                        )
+                        assert int(geometry_content) in {
+                            31,
+                            32,
+                        }, "2D geometry_content must be either 31, or 32"
                     else:
                         assert False, (
                             "geometry_content undefined for "
@@ -342,15 +344,15 @@ def validate_obj_per_dim_geometry_size(ids):
                             )
                         elif geometry_content == 21:
                             # contains 3 surface areas
-                            assert len(geometry) == 3, (
-                                "geometry length must be 3 for edge_areas"
-                            )
+                            assert (
+                                len(geometry) == 3
+                            ), "geometry length must be 3 for edge_areas"
                         elif geometry_content == 31:
                             # contains coordinate indices (ix, iy) and volume
                             # after extension
-                            assert len(geometry) == 3, (
-                                "geometry length must be 3 for face_indices_volume"
-                            )
+                            assert (
+                                len(geometry) == 3
+                            ), "geometry length must be 3 for face_indices_volume"
                         elif geometry_content == 32:
                             # contains coordinate indices (ix, iy), volume after
                             # extension, connection length, and distance
@@ -374,9 +376,9 @@ def validate_obj_0D_geometry_size(ids):
         for space in grid_ggd.space:
             obj_0D = space.objects_per_dimension[0]
             for obj in obj_0D.object:
-                assert len(obj.geometry) > 0, (
-                    "length of geometry of 0D objects must be > 0"
-                )
+                assert (
+                    len(obj.geometry) > 0
+                ), "length of geometry of 0D objects must be > 0"
 
 
 @multi_validator(GGD_PATHS_PER_IDS)
@@ -398,9 +400,9 @@ def validate_obj_per_dim_nodes_size(ids):
                     elif dim == 1:
                         assert len(nodes) == 2, "edges must contain 2 nodes"
                     else:
-                        assert len(nodes) >= dim + 1, (
-                            "n-order objects must contain at least n+1 nodes"
-                        )
+                        assert (
+                            len(nodes) >= dim + 1
+                        ), "n-order objects must contain at least n+1 nodes"
 
 
 @multi_validator(GGD_PATHS_PER_IDS)
@@ -414,9 +416,9 @@ def validate_obj_per_dim_nodes(ids):
                 for obj in obj_per_dim.object:
                     if obj.nodes.has_value:
                         assert (0 < obj.nodes).all(), "object nodes must be positive"
-                        assert (obj.nodes <= len_0D_obj).all(), (
-                            "object nodes must point to existing nodes"
-                        )
+                        assert (
+                            obj.nodes <= len_0D_obj
+                        ).all(), "object nodes must point to existing nodes"
 
 
 @multi_validator(GGD_PATHS_PER_IDS)
@@ -426,9 +428,9 @@ def validate_obj_per_dim_measure_empty(ids):
         for space in grid_ggd.space:
             obj_0D = space.objects_per_dimension[0]
             for obj in obj_0D.object:
-                assert not obj.measure.has_value or obj.measure.value == 0, (
-                    "measure of 0D objects must be empty or zero"
-                )
+                assert (
+                    not obj.measure.has_value or obj.measure.value == 0
+                ), "measure of 0D objects must be empty or zero"
 
 
 # Grid subset rules
@@ -446,9 +448,9 @@ def validate_grid_subset_identifier(ids):
 def validate_grid_subset_size(ids):
     """Validate that the grid has at least 1 grid subset."""
     for grid_ggd in get_defined_grids(ids):
-        assert len(grid_ggd.grid_subset) > 0, (
-            "GGD grid must have at least 1 grid_subset"
-        )
+        assert (
+            len(grid_ggd.grid_subset) > 0
+        ), "GGD grid must have at least 1 grid_subset"
 
 
 @multi_validator(GGD_PATHS_PER_IDS)
@@ -511,7 +513,8 @@ def validate_grid_subset_obj_dimension(ids):
                 for object in element.object:
                     obj_dim = object.dimension
                     assert subset_dim >= obj_dim, (
-                        "object dimension must be smaller or equal to the dimension of the grid subset"
+                        "object dimension must be smaller or equal to the dimension of "
+                        "the grid subset"
                     )
 
 
@@ -542,19 +545,19 @@ def validate_ggd_arrays(ids):
 
     for array in scalar_arrays + vector_arrays:
         for sub_array in array:
-            assert sub_array.grid_index.has_value, (
-                "the grid_index of a GGD array must be filled"
-            )
+            assert (
+                sub_array.grid_index.has_value
+            ), "the grid_index of a GGD array must be filled"
             grid_index = sub_array.grid_index
 
-            assert sub_array.grid_subset_index.has_value, (
-                "the grid_subset_index of a GGD array must be filled"
-            )
+            assert (
+                sub_array.grid_subset_index.has_value
+            ), "the grid_subset_index of a GGD array must be filled"
             grid_subset_index = sub_array.grid_subset_index
 
-            assert sub_array.has_value, (
-                "at least one quantity of a GGD array must be filled"
-            )
+            assert (
+                sub_array.has_value
+            ), "at least one quantity of a GGD array must be filled"
 
             matching_grid_ggd = find_structure_by_index(
                 get_grid_ggds(ids, descend_final=False), grid_index
@@ -577,9 +580,9 @@ def validate_ggd_arrays(ids):
                     quantity.metadata.name != "grid_index"
                     and quantity.metadata.name != "grid_subset_index"
                 ):
-                    assert len(grid_subset.element) == len(quantity), (
-                        "number of values in GGD array must match number of elements"
-                    )
+                    assert len(grid_subset.element) == len(
+                        quantity
+                    ), "number of values in GGD array must match number of elements"
 
 
 @multi_validator(GGD_PATHS_PER_IDS)

--- a/imas_validator/assets/rulesets/generic/ggd.py
+++ b/imas_validator/assets/rulesets/generic/ggd.py
@@ -233,10 +233,12 @@ def validate_grid_ggd_time(ids):
     the time nodes in the individual grid_ggd structures are filled."""
     if has_heterogeneous_time(ids):
         for grid_ggd in get_defined_grids(ids):
-            assert grid_ggd.time.has_value, (
-                "Time nodes in individual grid_ggd structures should be filled "
-                "for heterogeneous time"
-            )
+            # tf/field_map/grid does not have a time attribute
+            if hasattr(grid_ggd, "time"):
+                assert grid_ggd.time.has_value, (
+                    "Time nodes in individual grid_ggd structures should be filled "
+                    "for heterogeneous time"
+                )
 
 
 # Space rules


### PR DESCRIPTION
Fixes issues where the rules assume that the grid is always an array of structures. This is not the case for some GGD grids, (e.g. ``waves/coherent_wave()/full_wave()/grid``). Also skips the GGD grid time validation check if the grid doesn't have a time, (e.g. ``tf/field_map()/grid``).