### PR TITLE
ci: add dependabot.yml to update github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  # Enable version updates for Github Actions
+  - package-ecosystem: "github-actions"
+    # Look for `/.github/workflows` and `/action.yml` or `.yaml`
+    directory: "/"
+    # Check for updates once a week
+    schedule:
+      interval: "weekly"
+

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,4 +7,9 @@ updates:
     # Check for updates once a week
     schedule:
       interval: "weekly"
+    # Group actions version bumps into a single PR
+    groups:
+      actions-deps:
+        patterns:
+          - "*"
 


### PR DESCRIPTION
Let's see if on [Monday](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#interval), the versions of actions in `.github/workflows/*.yml` get bumped...